### PR TITLE
Feature/fix constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-# v0.1.6-dev
+# v0.2.0-dev
+* Bug Fixes
+  * Parsing null uuid's would break String check
+  * Allow references to be set for other primary key types
+  * Allow distincts on booleans
 
-# v0.1.5-dev
+# v0.1.5
 * Bug Fixes
   * Ecto.UUID tagged types were failing to be type checked in tds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.2.0-dev
+# v0.2.0
 * Bug Fixes
   * Parsing null uuid's would break String check
   * Allow references to be set for other primary key types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.5.0
+* Enhancements
+  * Updated to ecto 0.15.0
+
 # v0.4.0
 * Enhancements
   * Updated to ecto 0.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.3.1
+* Enhancements
+  * Updated tds to 0.4.0
+
 # v0.3.0
 * Enhancements
   * Updated to ecto 0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.1.1-dev
+# v0.1.1
 * Bug Fixes
   * Fixed limit: to map TOP in SELECT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# v0.3.0-dev
+# v0.2.5
 * Enhancements
-  * Updated Ecto to 0.12
+  * Updated Ecto to 0.12.1
+  * Added support for map type
+  * Added support for binary_id
 
 # v0.2.4
 * Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.5.0
+# v0.6.0
 * Enhancements
   * Updated to ecto 0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# v0.2.6-dev
+# v0.3.0
+* Enhancements
+  * Updated to ecto 0.13.0
+
 
 # v0.2.5
 * Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.3.2
+* Enhancements
+  * Lock down tds
+
 # v0.3.1
 * Enhancements
   * Updated tds to 0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.3.0-dev
+* Enhancements
+  * Updated Ecto to 0.12
+
 # v0.2.4
 * Enhancements
   * Updated Ecto to 0.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.4.0
+* Enhancements
+  * Updated to ecto 0.14.1
+
 # v0.3.0
 * Enhancements
   * Updated to ecto 0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
+# v0.1.6-dev
+
 # v0.1.5-dev
 * Bug Fixes
   * Ecto.UUID tagged types were failing to be type checked in tds
-  
+
 * Enhancements
   * Added support for UNIQUE in column definitions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.2.4
+* Enhancements
+  * Updated Ecto to 0.11
+
 # v0.2.3
 * Bug Fixes
   * Changed tablename quoting to allow for schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.2.1-dev
+* Bug Fixes
+  * Use datetime2 when time struct usec > 0
+
 # v0.2.0
 * Bug Fixes
   * Parsing null uuid's would break String check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.4
+* Bug Fixes
+  * Added :tds to application list
+
 # v0.1.3
 * Bug Fixes
   * Fixing deps issue with Hex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.2.3
+* Bug Fixes
+  * Changed tablename quoting to allow for schema
+
 # v0.2.2
 * Enhancements
   * Updated Ecto version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.3
+* Bug Fixes
+  * Fixing deps issue with Hex
+
 # v0.1.2
 * Bug Fixes
   * Added lock to join/2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 
+# v0.1.0 (2015-02-13)
+* Enhancements
+  * Updated Deps
+
+
 # v0.0.1 (2015-02-12)
 * First Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# v0.2.1-dev
+# v0.2.2
+* Enhancements
+  * Updated Ecto version
+
+# v0.2.1
 * Bug Fixes
   * Use datetime2 when time struct usec > 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.0
+* Enhancements
+  * Updated to ecto 1.0.0
+
 # v0.6.0
 * Enhancements
   * Updated to ecto 0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v0.2.6-dev
+
 # v0.2.5
 * Enhancements
   * Updated Ecto to 0.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # v0.1.5-dev
+* Bug Fixes
+  * Ecto.UUID tagged types were failing to be type checked in tds
+  
 * Enhancements
   * Added support for UNIQUE in column definitions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v0.5.0
 * Enhancements
+  * Updated to ecto 0.16.0
+
+# v0.5.0
+* Enhancements
   * Updated to ecto 0.15.0
 
 # v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.2-dev
+* Bug Fixes
+  * Added lock to join/2
+
 # v0.1.1
 * Bug Fixes
   * Fixed limit: to map TOP in SELECT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.1.2-dev
+# v0.1.2
 * Bug Fixes
   * Added lock to join/2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.1.1-dev
+* Bug Fixes
+  * Fixed limit: to map TOP in SELECT
 
 # v0.1.0 (2015-02-13)
 * Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.5-dev
+* Enhancements
+  * Added support for UNIQUE in column definitions
+
 # v0.1.4
 * Bug Fixes
   * Added :tds to application list

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ MSSQL / TDS Adapter for Ecto
 
 ## Example
 ```elixir
-# In your config/config.exs file
-# by default it use port 1433, different port can be specified with `port:` 1434 option and
-# named instance with `instance:` "instance_name" option
+# In your config/config.exs file add MSSQL connection options
+# By default it use port 1433, different port can be specified with 
+# port: 1434
+# option and named instance with 
+# instance: "instance_name"
 config :my_app, Repo,
   database: "ecto_simple",
   username: "mssql",

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ MSSQL / TDS Adapter for Ecto
 ## Example
 ```elixir
 # In your config/config.exs file add MSSQL connection options
-# By default it use port 1433, different port can be specified with 
+# By default it use port 1433, different port can be specified with
 # port: 1434
-# option and named instance with 
+# option and named instance with
 # instance: "instance_name"
 config :my_app, Repo,
   database: "ecto_simple",
@@ -109,7 +109,7 @@ Additionally SQL authentication needs to be used for connecting and testing. Add
 
 ## License
 
-   Copyright 2014 LiveHelpNow
+   Copyright 2014, 2015 LiveHelpNow
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ MSSQL / TDS Adapter for Ecto
 ## Example
 ```elixir
 # In your config/config.exs file
+# by default it use port 1433, different port can be specified with `port:` 1434 option and
+# named instance with `instance:` "instance_name" option
 config :my_app, Repo,
   database: "ecto_simple",
   username: "mssql",

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add Tds as a dependency in your `mix.exs` file.
 
 ```elixir
 def deps do
-  [{:tds_ecto, "~> 0.1"}]
+  [{:tds_ecto, "~> 0.2"}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,28 +47,27 @@ Add Tds as a dependency in your `mix.exs` file.
 
 ```elixir
 def deps do
-  [{:tds_ecto, "~> 0.1"} ]
+  [{:tds_ecto, "~> 0.1"}]
 end
 ```
 
 You should also update your applications list to include both projects:
 ```elixir
 def application do
-  [applications: [:postgrex, :ecto]]
+  [applications: [:logger, :tds_ecto, :ecto]]
 end
 ```
 
 To use the adapter in your repo:
 ```elixir
-defmodule MyProject.TestRepo do
+defmodule MyApp.Repo do
   use Ecto.Repo,
-    otp_app: :ecto,
+    otp_app: :my_app,
     adapter: Tds.Ecto
 end
 ```
 
-For additional information on usage please see the documentation for Ecto
-http://hexdocs.pm/ecto
+For additional information on usage please see the documentation for [Ecto](http://hexdocs.pm/ecto).
 
 ## Contributing
 
@@ -84,7 +83,7 @@ The tests require an addition to your hosts file to connect to your sql server d
 
 <IP OF SQL SERVER>	mssql.local
 
-Additionally SQL authentication needs to be used for connecting and testing. Add the user test_user with access to the database test_db. See one of the test files for the connection information and port number.
+Additionally SQL authentication needs to be used for connecting and testing. Add the user `test_user` with access to the database `test_db`. See one of the test files for the connection information and port number.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -70,21 +70,21 @@ end
 For additional information on usage please see the documentation for [Ecto](http://hexdocs.pm/ecto).
 
 ## Data Type Mapping
-MSSQL datatypes are mapped to the following Ecto datatypes
-	MSSQL             Ecto
-    ----------        ------
-    nvarchar          :string
-    varchar			  :binary
-    char              :binary
-    varbinary		  :binary
-    float             :float
-    decimal           :decimal
-    integer 		  :integer
-    bit 			  :boolean
-    uniqueidentifier  :uuid
-    datetime		  :datetime
-    date			  :date
-    time 			  :time
+
+	MSSQL             	Ecto
+	----------        	------
+	nvarchar          	:string
+	varchar			  	:binary
+	char              	:binary
+	varbinary		  	:binary
+	float             	:float
+	decimal           	:decimal
+	integer 		  	:integer
+	bit 			  	:boolean
+	uniqueidentifier  	:uuid
+	datetime		  	:datetime
+	date			  	:date
+	time 			  	:time
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ end
 
 For additional information on usage please see the documentation for [Ecto](http://hexdocs.pm/ecto).
 
+## Data Type Mapping
+MSSQL datatypes are mapped to the following Ecto datatypes
+	MSSQL             Ecto
+    ----------        ------
+    nvarchar          :string
+    varchar			  :binary
+    char              :binary
+    varbinary		  :binary
+    float             :float
+    decimal           :decimal
+    integer 		  :integer
+    bit 			  :boolean
+    uniqueidentifier  :uuid
+    datetime		  :datetime
+    date			  :date
+    time 			  :time
+
+
 ## Contributing
 
 To contribute you need to compile Tds from source and test it:

--- a/lib/tds_ecto.ex
+++ b/lib/tds_ecto.ex
@@ -57,6 +57,8 @@ defmodule Tds.Ecto do
   use Ecto.Adapters.SQL, :tds
   @behaviour Ecto.Adapter.Storage
 
+  def id_types(_repo), do: %{binary_id: Ecto.UUID}
+
   def storage_up(opts) do
     database = Keyword.fetch!(opts, :database)
 

--- a/lib/tds_ecto.ex
+++ b/lib/tds_ecto.ex
@@ -20,6 +20,12 @@ defmodule Tds.Ecto do
   below. All options should be given via the repository
   configuration.
 
+  ### Compile time options
+  Those options should be set in the config file and require
+  recompilation in order to make an effect.
+    * `:adapter` - The adapter name, in this case, `Tds.Ecto`
+    * `:timeout` - The default timeout to use on queries, defaults to `5000`
+
   ### Connection options
 
     * `:hostname` - Server hostname

--- a/lib/tds_ecto.ex
+++ b/lib/tds_ecto.ex
@@ -103,7 +103,7 @@ defmodule Tds.Ecto do
         # Execute the query
         case Tds.Ecto.Connection.query(pid, sql_command, [], []) do
           {:ok, %{}} -> {:ok, 0}
-          {_, %Tds.Error{message: message, mssql: error}} ->
+          {_, %Tds.Error{message: _message, mssql: error}} ->
             {error, 1}
         end
       {_,error} -> 

--- a/lib/tds_ecto.ex
+++ b/lib/tds_ecto.ex
@@ -50,6 +50,8 @@ defmodule Tds.Ecto do
     * `:lc_ctype` - the character classification
 
   """
+
+  require Logger
   require Tds
   use Ecto.Adapters.SQL, :tds
   @behaviour Ecto.Adapter.Storage
@@ -85,7 +87,10 @@ defmodule Tds.Ecto do
   end
 
   defp run_with_sql_conn(opts, sql_command) do
-    opts = opts |> Keyword.put(:database, "master")
+    host = opts[:hostname] || System.get_env("MSSQLHOST") || "localhost"
+    opts = opts 
+      |> Keyword.put(:database, "master")
+      |> Keyword.put(:hostname, host)
     case Tds.Ecto.Connection.connect(opts) do
       {:ok, pid} ->
         # Execute the query

--- a/lib/tds_ecto.ex
+++ b/lib/tds_ecto.ex
@@ -57,7 +57,17 @@ defmodule Tds.Ecto do
   use Ecto.Adapters.SQL, :tds
   @behaviour Ecto.Adapter.Storage
 
-  #def id_types(_repo), do: %{binary_id: Ecto.UUID}
+  ## Custom MSSQL types
+
+  def load({:embed, _} = type, binary) when is_binary(binary),
+    do: super(type, json_library.decode!(binary))
+  def load(:map, binary) when is_binary(binary),
+    do: super(:map, json_library.decode!(binary))
+  def load(:boolean, 0), do: {:ok, false}
+  def load(:boolean, 1), do: {:ok, true}
+  def load(type, value), do: super(type, value)
+
+  defp json_library, do: Application.get_env(:ecto, :json_library)
 
   def storage_up(opts) do
     database = Keyword.fetch!(opts, :database)

--- a/lib/tds_ecto.ex
+++ b/lib/tds_ecto.ex
@@ -1,5 +1,5 @@
 defmodule Tds.Ecto do
-  
+
   @moduledoc """
   Adapter module for MSSQL.
 
@@ -57,7 +57,7 @@ defmodule Tds.Ecto do
   use Ecto.Adapters.SQL, :tds
   @behaviour Ecto.Adapter.Storage
 
-  def id_types(_repo), do: %{binary_id: Ecto.UUID}
+  #def id_types(_repo), do: %{binary_id: Ecto.UUID}
 
   def storage_up(opts) do
     database = Keyword.fetch!(opts, :database)
@@ -97,7 +97,7 @@ defmodule Tds.Ecto do
 
   defp run_with_sql_conn(opts, sql_command) do
     host = opts[:hostname] || System.get_env("MSSQLHOST") || "localhost"
-    opts = opts 
+    opts = opts
       |> Keyword.put(:database, "master")
       |> Keyword.put(:hostname, host)
     case Tds.Ecto.Connection.connect(opts) do
@@ -108,7 +108,7 @@ defmodule Tds.Ecto do
           {_, %Tds.Error{message: _message, mssql: error}} ->
             {error, 1}
         end
-      {_,error} -> 
+      {_,error} ->
         {error, 1}
     end
   end

--- a/lib/tds_ecto.ex
+++ b/lib/tds_ecto.ex
@@ -26,6 +26,9 @@ defmodule Tds.Ecto do
     * `:adapter` - The adapter name, in this case, `Tds.Ecto`
     * `:timeout` - The default timeout to use on queries, defaults to `5000`
 
+  ### Repo options
+    * `:filter_null_on_unique_indexes` - Allows unique indexes to filter out null and only match on NOT NULL values
+
   ### Connection options
 
     * `:hostname` - Server hostname
@@ -50,8 +53,6 @@ defmodule Tds.Ecto do
     * `:lc_ctype` - the character classification
 
   """
-
-  require Logger
   require Tds
   use Ecto.Adapters.SQL, :tds
   @behaviour Ecto.Adapter.Storage
@@ -84,6 +85,12 @@ defmodule Tds.Ecto do
       output != nil -> if String.contains?(output[:msg_text], "does not exist"), do: {:error, :already_down}
       true                                       -> {:error, output}
     end
+  end
+
+  def execute_ddl(repo, definition, opts) do
+    sql = @conn.execute_ddl(definition, repo)
+    Ecto.Adapters.SQL.query(repo, sql, [], opts)
+    :ok
   end
 
   defp run_with_sql_conn(opts, sql_command) do

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -63,9 +63,10 @@ if Code.ensure_loaded?(Tds.Connection) do
     end
 
     defp param(value) when is_binary(value) do
-      value = value
-        |> :unicode.characters_to_binary(:utf8, {:utf16, :little})
-      {value, nil}
+      case :unicode.characters_to_binary(value, :utf8, {:utf16, :little}) do
+        {:error, _, _} -> {value, :binary}
+        val -> {val, nil}
+      end
     end
     defp param(value) when value == true, do: {1, :boolean}
     defp param(value) when value == false, do: {0, :boolean}
@@ -566,6 +567,7 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp column_type({:array, _type}, _opts),
       do: raise "Array column type is not supported for MSSQL"
     defp column_type(:uuid, _opts), do: "uniqueidentifier"
+    defp column_type(:binary_id, _opts), do: "uniqueidentifier"
     defp column_type(type, opts) do
       pk        = Keyword.get(opts, :primary_key)
       size      = Keyword.get(opts, :size)

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -197,7 +197,7 @@ if Code.ensure_loaded?(Tds.Connection) do
 
     defp select(%SelectExpr{fields: fields}, limit, [], sources) do
       #IO.inspect limit
-      "SELECT " <> Enum.map_join(fields, ", ", &expr(&1, sources)) 
+      "SELECT " <> limit(limit, sources) <> Enum.map_join(fields, ", ", &expr(&1, sources)) 
     end
 
     defp select(%SelectExpr{fields: fields}, limit, distincts, sources) do
@@ -207,7 +207,7 @@ if Code.ensure_loaded?(Tds.Connection) do
             Enum.map_join(expr, ", ", &expr(&1, sources))
         end)
 
-      "SELECT DISTINCT " <> exprs
+      "SELECT DISTINCT " <> limit(limit, sources) <> exprs
     end
 
     defp from(sources, lock) do
@@ -275,9 +275,9 @@ if Code.ensure_loaded?(Tds.Connection) do
       end
     end
 
-    defp limit(nil, _sources), do: nil
+    defp limit(nil, _sources), do: ""
     defp limit(%Ecto.Query.QueryExpr{expr: expr}, sources) do
-      "LIMIT " <> expr(expr, sources)
+      "TOP(" <> expr(expr, sources) <> ") "
     end
 
     defp offset(nil, _sources), do: nil

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -503,7 +503,7 @@ if Code.ensure_loaded?(Tds.Connection) do
       assemble(["DROP INDEX", quote_table_name(index.name), " ON ", quote_table_name(index.table)])
     end
 
-    def execute_ddl(default, _repo \\ nil) when is_binary(default), do: default
+    def execute_ddl(default, _repo) when is_binary(default), do: default
 
     defp column_definitions(columns) do
       Enum.map_join(columns, ", ", &column_definition/1)

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -2,8 +2,6 @@ if Code.ensure_loaded?(Tds.Connection) do
   defmodule Tds.Ecto.Connection do
     @moduledoc false
 
-    require Logger
-
     @default_port System.get_env("MSSQLPORT") || 1433
     @behaviour Ecto.Adapters.SQL.Connection
 
@@ -24,6 +22,7 @@ if Code.ensure_loaded?(Tds.Connection) do
 
     def query(conn, sql, params, opts) do
       {params, _} = Enum.map_reduce params, 1, fn(param, acc) ->
+
         {value, type} = case param do
           %Ecto.Query.Tagged{value: value, type: :boolean} -> 
               value = if value == true, do: 1, else: 0
@@ -32,6 +31,7 @@ if Code.ensure_loaded?(Tds.Connection) do
             type = if value == "", do: :string, else: :binary
             {value, type}
           %Ecto.Query.Tagged{value: {{y,m,d},{hh,mm,ss,us}}, type: :datetime} -> 
+
             cond do
               us > 0 -> {{{y,m,d},{hh,mm,ss, us}}, :datetime2}
               true -> {{{y,m,d},{hh,mm,ss}}, :datetime}

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -105,7 +105,7 @@ if Code.ensure_loaded?(Tds.Connection) do
 
       from     = from(sources, query.lock)
       select   = select(query.select, query.limit, query.distincts, sources)
-      join     = join(query.joins, sources)
+      join     = join(query.joins, sources, query.lock)
       where    = where(query.wheres, sources)
       group_by = group_by(query.group_bys, sources)
       having   = having(query.havings, sources)
@@ -215,8 +215,8 @@ if Code.ensure_loaded?(Tds.Connection) do
       "FROM #{quote_name(table)} AS #{name} " <> lock(lock)
     end
 
-    defp join([], _sources), do: nil
-    defp join(joins, sources) do
+    defp join([], _sources, _lock), do: nil
+    defp join(joins, sources, lock) do
       Enum.map_join(joins, " ", fn
         %JoinExpr{on: %QueryExpr{expr: expr}, qual: qual, ix: ix} ->
           {table, name, _model} = elem(sources, ix)
@@ -224,7 +224,7 @@ if Code.ensure_loaded?(Tds.Connection) do
           on   = expr(expr, sources)
           qual = join_qual(qual)
 
-          "#{qual} JOIN #{quote_name(table)} AS #{name} ON " <> on
+          "#{qual} JOIN #{quote_name(table)} AS #{name} " <> lock <> " ON " <> on
       end)
     end
 

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -83,7 +83,8 @@ if Code.ensure_loaded?(Tds.Connection) do
       case :binary.split(message, "unique index ") do
         [_, quoted] ->
           case :binary.split(quoted, ". The") do
-            [quoted, _] -> [unique: strip_quotes(quoted)]
+            [quoted, _] ->
+              [unique: strip_quotes(quoted)]
             _ -> []
           end
         _ -> []
@@ -93,7 +94,8 @@ if Code.ensure_loaded?(Tds.Connection) do
       case :binary.split(message, "constraint ") do
         [_, quoted] ->
           case :binary.split(quoted, ". The") do
-            [quoted, _] -> [unique: strip_quotes(quoted)]
+            [quoted, _] ->
+              [foreign_key: strip_quotes(quoted)]
             _ -> []
           end
         _ -> []

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -104,6 +104,7 @@ if Code.ensure_loaded?(Tds.Connection) do
 
     ## Query
 
+    alias Ecto.Query
     alias Ecto.Query.SelectExpr
     alias Ecto.Query.QueryExpr
     alias Ecto.Query.JoinExpr
@@ -112,17 +113,16 @@ if Code.ensure_loaded?(Tds.Connection) do
       sources = create_names(query)
 
       from     = from(sources, query.lock)
-      select   = select(query.select, query.limit, query.distinct, sources)
-      join     = join(query.joins, sources, query.lock)
-      where    = where(query.wheres, sources)
-      group_by = group_by(query.group_bys, sources)
-      having   = having(query.havings, sources)
-      order_by = order_by(query.order_bys, sources)
+      select   = select(query, sources)
+      join     = join(query, sources)
+      where    = where(query, sources)
+      group_by = group_by(query, sources)
+      having   = having(query, sources)
+      order_by = order_by(query, sources)
 
-      offset   = offset(query.offset, sources)
-      # lock     = lock(query.lock)
-      # unlock   = unlock(query.lock)
-      if (query.offset != nil and query.order_bys == []), do: raise(ArgumentError, "ORDER BY is mandatory to use OFFSET")
+      offset   = offset(query, sources)
+
+      if (query.offset != nil and query.order_bys == []), do: error!(query, "ORDER BY is mandatory to use OFFSET")
       assemble([select, from, join, where, group_by, having, order_by, offset])
     end
 
@@ -131,10 +131,10 @@ if Code.ensure_loaded?(Tds.Connection) do
       {table, name, _model} = elem(sources, 0)
 
       update = "UPDATE #{name}"
-      fields = update_fields(query.updates, sources)
+      fields = update_fields(query, sources)
       from   = "FROM #{table} AS #{name}"
-      join   = join(query.joins, sources, query.lock)
-      where  = where(query.wheres, sources)
+      join   = join(query, sources)
+      where  = where(query, sources)
 
       assemble([update, "SET", fields, from, join, where])
     end
@@ -145,8 +145,8 @@ if Code.ensure_loaded?(Tds.Connection) do
 
       delete = "DELETE #{name}"
       from   = "FROM #{table} AS #{name}"
-      join   = join(query.joins, sources, query.lock)
-      where  = where(query.wheres, sources)
+      join   = join(query, sources)
+      where  = where(query, sources)
 
       assemble([delete, from, join, where])
     end
@@ -201,23 +201,22 @@ if Code.ensure_loaded?(Tds.Connection) do
 
     defp handle_call(fun, _arity), do: {:fun, Atom.to_string(fun)}
 
-    defp select(%SelectExpr{fields: fields}, limit, [], sources) do
-      #IO.inspect limit
-      "SELECT " <> limit(limit, sources) <> Enum.map_join(fields, ", ", &expr(&1, sources))
+    defp select(%Query{select: %SelectExpr{fields: fields}, distinct: []} = query, sources) do
+      "SELECT " <> limit(query, sources) <> Enum.map_join(fields, ", ", &expr(&1, sources, query))
     end
 
-    defp select(%SelectExpr{fields: fields}, limit, distinct, sources) do
+    defp select(%Query{select: %SelectExpr{fields: fields}} = query, sources) do
       "SELECT " <>
-        distinct(distinct, sources) <>
-        limit(limit, sources) <>
-        Enum.map_join(fields, ", ", &expr(&1, sources))
+        distinct(query, sources) <>
+        limit(query, sources) <>
+        Enum.map_join(fields, ", ", &expr(&1, sources, query))
     end
 
-    defp distinct(nil, _sources), do: ""
-    defp distinct(%QueryExpr{expr: true}, _sources),  do: "DISTINCT "
-    defp distinct(%QueryExpr{expr: false}, _sources), do: ""
-    defp distinct(%QueryExpr{expr: _exprs}, _sources) do
-      raise ArgumentError, "MSSQL does not allow expressions in distinct"
+    defp distinct(%Query{distinct: nil}, _sources), do: ""
+    defp distinct(%Query{distinct: %QueryExpr{expr: true}}, _sources),  do: "DISTINCT "
+    defp distinct(%Query{distinct: %QueryExpr{expr: false}}, _sources), do: ""
+    defp distinct(%Query{distinct: %QueryExpr{expr: _exprs}} = query, _sources) do
+      error!(query, "MSSQL does not allow expressions in distinct")
     end
 
     defp from(sources, lock) do
@@ -225,38 +224,38 @@ if Code.ensure_loaded?(Tds.Connection) do
       "FROM #{table} AS #{name}" <> lock(lock) |> String.strip
     end
 
-    defp update_fields(updates, sources) do
+    defp update_fields(%Query{updates: updates} = query, sources) do
       for(%{expr: expr} <- updates,
           {op, kw} <- expr,
           {key, value} <- kw,
-          do: update_op(op, key, value, sources)) |> Enum.join(", ")
+          do: update_op(op, key, value, sources, query)) |> Enum.join(", ")
     end
 
-    defp update_op(:set, key, value, sources) do
+    defp update_op(:set, key, value, sources, query) do
       {_table, name, _model} = elem(sources, 0)
-      name <> "." <> quote_name(key) <> " = " <> expr(value, sources)
+      name <> "." <> quote_name(key) <> " = " <> expr(value, sources, query)
     end
 
-    defp update_op(:inc, key, value, sources) do
+    defp update_op(:inc, key, value, sources, query) do
       {_table, name, _model} = elem(sources, 0)
       quoted = quote_name(key)
-      name <> "." <> quoted <> " = " <> name <> "." <> quoted <> " + " <> expr(value, sources)
+      name <> "." <> quoted <> " = " <> name <> "." <> quoted <> " + " <> expr(value, sources, query)
     end
 
-    defp update_op(command, _key, _value, _sources) do
-      raise ArgumentError, "Unknown update operation #{inspect command} for MSSQL"
+    defp update_op(command, _key, _value, _sources, query) do
+      error!(query, "Unknown update operation #{inspect command} for MSSQL")
     end
 
-    defp join([], _sources, _lock), do: nil
-    defp join(joins, sources, lock) do
-      Enum.map_join(joins, " ", fn
+    defp join(%Query{joins: []}, _sources), do: nil
+    defp join(%Query{joins: joins, lock: lock} = query, sources) do
+      Enum.map_join(query.joins, " ", fn
         %JoinExpr{on: %QueryExpr{expr: expr}, qual: qual, ix: ix} ->
           {table, name, _model} = elem(sources, ix)
 
-          on   = expr(expr, sources)
+          on   = expr(expr, sources, query)
           qual = join_qual(qual)
 
-          "#{qual} JOIN #{table} AS #{name} " <> lock(lock) <> "ON " <> on
+          "#{qual} JOIN #{table} AS #{name} " <> lock(query.lock) <> "ON " <> on
       end)
     end
 
@@ -265,19 +264,19 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp join_qual(:right), do: "RIGHT OUTER"
     defp join_qual(:full),  do: "FULL OUTER"
 
-    defp where(wheres, sources) do
-      boolean("WHERE", wheres, sources)
+    defp where(%Query{wheres: wheres} = query, sources) do
+      boolean("WHERE", wheres, sources, query)
     end
 
-    defp having(havings, sources) do
-      boolean("HAVING", havings, sources)
+    defp having(%Query{havings: havings} = query, sources) do
+      boolean("HAVING", havings, sources, query)
     end
 
-    defp group_by(group_bys, sources) do
+    defp group_by(%Query{group_bys: group_bys} = query, sources) do
       exprs =
         Enum.map_join(group_bys, ", ", fn
           %QueryExpr{expr: expr} ->
-            Enum.map_join(expr, ", ", &expr(&1, sources))
+            Enum.map_join(expr, ", ", &expr(&1, sources, query))
         end)
 
       case exprs do
@@ -286,11 +285,11 @@ if Code.ensure_loaded?(Tds.Connection) do
       end
     end
 
-    defp order_by(order_bys, sources) do
+    defp order_by(%Query{order_bys: order_bys} = query, sources) do
       exprs =
         Enum.map_join(order_bys, ", ", fn
           %QueryExpr{expr: expr} ->
-            Enum.map_join(expr, ", ", &order_by_expr(&1, sources))
+            Enum.map_join(expr, ", ", &order_by_expr(&1, sources, query))
         end)
 
       case exprs do
@@ -299,167 +298,181 @@ if Code.ensure_loaded?(Tds.Connection) do
       end
     end
 
-    defp order_by_expr({dir, expr}, sources) do
-      str = expr(expr, sources)
+    defp order_by_expr({dir, expr}, sources, query) do
+      str = expr(expr, sources, query)
       case dir do
         :asc  -> str
         :desc -> str <> " DESC"
       end
     end
 
-    defp limit(nil, _sources), do: ""
-    defp limit(%Ecto.Query.QueryExpr{expr: expr}, sources) do
-      "TOP(" <> expr(expr, sources) <> ") "
+    defp limit(%Query{limit: nil}, _sources), do: ""
+    defp limit(%Query{limit: %QueryExpr{expr: expr}} = query, sources) do
+      "TOP(" <> expr(expr, sources, query) <> ") "
     end
 
-    defp offset(nil, _sources), do: nil
-    defp offset(%Ecto.Query.QueryExpr{expr: expr}, sources) do
-      "OFFSET " <> expr(expr, sources) <> " ROW"
+    defp offset(%Query{offset: nil}, _sources), do: nil
+    defp offset(%Query{offset: %Ecto.Query.QueryExpr{expr: expr}} = query, sources) do
+      "OFFSET " <> expr(expr, sources, query) <> " ROW"
     end
 
     defp lock(nil), do: ""
     defp lock(lock_clause), do: " #{lock_clause} "
 
-    defp boolean(_name, [], _sources), do: nil
-    defp boolean(name, query_exprs, sources) do
+    defp boolean(_name, [], _sources, query), do: nil
+    defp boolean(name, query_exprs, sources, query) do
       name <> " " <>
         Enum.map_join(query_exprs, " AND ", fn
           %QueryExpr{expr: expr} ->
-            "(" <> expr(expr, sources) <> ")"
+            "(" <> expr(expr, sources, query) <> ")"
         end)
     end
 
-    defp expr({:^, [], [ix]}, _sources) do
+    defp expr({:^, [], [ix]}, _sources, _query) do
       "@#{ix+1}"
     end
 
-    defp expr({{:., _, [{:&, _, [idx]}, field]}, _, []}, sources) when is_atom(field) do
+    defp expr({{:., _, [{:&, _, [idx]}, field]}, _, []} = p1, sources, _query) when is_atom(field) do
       {_, name, _} = elem(sources, idx)
       "#{name}.#{quote_name(field)}"
     end
 
-    defp expr({:&, _, [idx]}, sources) do
+    defp expr({:&, _, [idx]}, sources, query) do
       {table, name, model} = elem(sources, idx)
       unless model do
-        raise ArgumentError, "MSSQL requires a model when using selector #{inspect name} but " <>
+        error!(query, "MSSQL requires a model when using selector #{inspect name} but " <>
                              "only the table #{inspect table} was given. Please specify a model " <>
-                             "or specify exactly which fields from #{inspect name} you desire"
+                             "or specify exactly which fields from #{inspect name} you desire")
       end
       fields = model.__schema__(:fields)
       Enum.map_join(fields, ", ", &"#{name}.#{quote_name(&1)}")
     end
 
-    defp expr({:in, _, [_left, []]}, _sources) do
+    defp expr({:in, _, [_left, []]}, _sources, _query) do
       "0=1"
     end
 
-    defp expr({:in, _, [left, right]}, sources) when is_list(right) do
-      args = Enum.map_join right, ",", &expr(&1, sources)
-      expr(left, sources) <> " IN (" <> args <> ")"
+    defp expr({:in, _, [left, right]}, sources, query) when is_list(right) do
+      args = Enum.map_join right, ",", &expr(&1, sources, query)
+      expr(left, sources, query) <> " IN (" <> args <> ")"
     end
 
-    defp expr({:in, _, [left, {:^, _, [ix, length]}]}, sources) do
+    defp expr({:in, _, [left, {:^, _, [ix, length]}]}, sources, query) do
       args = Enum.map_join ix+1..ix+length, ",", &"@#{&1}"
-      expr(left, sources) <> " IN (" <> args <> ")"
+      expr(left, sources, query) <> " IN (" <> args <> ")"
     end
 
-    defp expr({:in, _, [left, right]}, sources) do
-      expr(left, sources) <> " IN (" <> expr(right, sources) <> ")"
+    defp expr({:in, _, [left, right]}, sources, query) do
+      expr(left, sources, query) <> " IN (" <> expr(right, sources, query) <> ")"
     end
 
-    defp expr({:is_nil, _, [arg]}, sources) do
-      "#{expr(arg, sources)} IS NULL"
+    defp expr({:is_nil, _, [arg]}, sources, query) do
+      "#{expr(arg, sources, query)} IS NULL"
     end
 
-    defp expr({:not, _, [expr]}, sources) do
-      "NOT (" <> expr(expr, sources) <> ")"
+    defp expr({:not, _, [expr]}, sources, query) do
+      "NOT (" <> expr(expr, sources, query) <> ")"
     end
 
-    defp expr({:fragment, _, [kw]}, _sources) when is_list(kw) or tuple_size(kw) == 3 do
-      raise ArgumentError, "MSSQL adapter does not support keyword or interpolated fragments"
+    defp expr({:fragment, _, [kw]}, _sources, query) when is_list(kw) or tuple_size(kw) == 3 do
+      error!(query, "MSSQL adapter does not support keyword or interpolated fragments")
     end
 
-    defp expr({:fragment, _, parts}, sources) do
+    defp expr({:fragment, _, parts}, sources, query) do
       Enum.map_join(parts, "", fn
         {:raw, part}  -> part
-        {:expr, expr} -> expr(expr, sources)
+        {:expr, expr} -> expr(expr, sources, query)
       end)
     end
 
     defp expr({:datetime_add, _, [datetime, count, interval]}, sources, query) do
-      "CAST(DATEADD(" <> interval <> ", " <> count <> ", " <> expr(date, sources, query) <>
-        ", " <> ") AS datetime)"
+      "CAST(DATEADD(" <>
+        interval <> ", " <> interval_count(count, sources, query) <> ", " <> expr(datetime, sources, query) <>
+        ") AS datetime2)"
     end
 
     defp expr({:date_add, _, [date, count, interval]}, sources, query) do
-      "CAST(DATEADD(" <> interval <> ", " <> count <> ", " <> expr(date, sources, query) <>
-        ", " <> ") AS date)"
+      "CAST(DATEADD(" <>
+        interval <> ", " <> interval_count(count, sources, query) <> ", CAST(" <> expr(date, sources, query) <> " AS datetime2)" <>
+        ") AS date)"
     end
 
-    defp expr({fun, _, args}, sources) when is_atom(fun) and is_list(args) do
+    defp expr({fun, _, args}, sources, query) when is_atom(fun) and is_list(args) do
       case handle_call(fun, length(args)) do
         {:binary_op, op} ->
           [left, right] = args
-          op_to_binary(left, sources) <>
+          op_to_binary(left, sources, query) <>
           " #{op} "
-          <> op_to_binary(right, sources)
+          <> op_to_binary(right, sources, query)
 
         {:fun, fun} ->
-          "#{fun}(" <> Enum.map_join(args, ", ", &expr(&1, sources)) <> ")"
+          "#{fun}(" <> Enum.map_join(args, ", ", &expr(&1, sources, query)) <> ")"
       end
     end
 
-    defp expr(list, sources) when is_list(list) do
-      Enum.map_join(list, ", ", &expr(&1, sources))
+    defp expr(list, sources, query) when is_list(list) do
+      Enum.map_join(list, ", ", &expr(&1, sources, query))
     end
 
-    defp expr(string, _sources) when is_binary(string) do
+    defp expr(string, _sources, _query) when is_binary(string) do
       hex = string
         |> :unicode.characters_to_binary(:utf8, {:utf16, :little})
         |> Base.encode16(case: :lower)
       "CONVERT(nvarchar(max), 0x#{hex})"
     end
 
-    defp expr(%Decimal{} = decimal, _sources) do
+    defp expr(%Decimal{} = decimal, _sources, _query) do
       Decimal.to_string(decimal, :normal)
     end
 
-    defp expr(%Ecto.Query.Tagged{value: binary, type: :binary}, _sources) when is_binary(binary) do
+    defp expr(%Ecto.Query.Tagged{value: binary, type: :binary}, _sources, _query) when is_binary(binary) do
       hex = Base.encode16(binary, case: :lower)
       "0x#{hex}"
     end
 
-    defp expr(%Ecto.Query.Tagged{value: binary, type: :uuid}, _sources) when is_binary(binary) do
+    defp expr(%Ecto.Query.Tagged{value: binary, type: :uuid}, _sources, _query) when is_binary(binary) do
       if String.contains?(binary, "-"), do: {:ok, binary} = Ecto.UUID.dump(binary)
       uuid(binary)
     end
 
-    defp expr(%Ecto.Query.Tagged{value: other, type: type}, sources) do
-      "CAST(#{expr(other, sources)} AS #{column_type(type, [])})"
+    defp expr(%Ecto.Query.Tagged{value: other, type: type}, sources, query) do
+      "CAST(#{expr(other, sources, query)} AS #{column_type(type, [])})"
     end
 
-    defp expr(nil, _sources),   do: "NULL"
-    defp expr(true, _sources),  do: "1"
-    defp expr(false, _sources), do: "0"
+    defp expr(nil, _sources, _query),   do: "NULL"
+    defp expr(true, _sources, _query),  do: "1"
+    defp expr(false, _sources, _query), do: "0"
 
-    defp expr(literal, _sources) when is_binary(literal) do
+    defp expr(literal, _sources, _query) when is_binary(literal) do
       "'#{escape_string(literal)}'"
     end
 
-    defp expr(literal, _sources) when is_integer(literal) do
+    defp expr(literal, _sources, _query) when is_integer(literal) do
       String.Chars.Integer.to_string(literal)
     end
 
-    defp expr(literal, _sources) when is_float(literal) do
+    defp expr(literal, _sources, _query) when is_float(literal) do
       String.Chars.Float.to_string(literal)
     end
 
-    defp op_to_binary({op, _, [_, _]} = expr, sources) when op in @binary_ops do
-      "(" <> expr(expr, sources) <> ")"
+    defp op_to_binary({op, _, [_, _]} = expr, sources, query) when op in @binary_ops do
+      "(" <> expr(expr, sources, query) <> ")"
     end
 
-    defp op_to_binary(expr, sources) do
-      expr(expr, sources)
+    defp op_to_binary(expr, sources, query) do
+      expr(expr, sources, query)
+    end
+
+    defp interval_count(count, _sources, _query) when is_integer(count) do
+      String.Chars.Integer.to_string(count)
+    end
+
+    defp interval_count(count, _sources, _query) when is_float(count) do
+      :erlang.float_to_binary(count, [:compact, decimals: 16])
+    end
+
+    defp interval_count(count, sources, query) do
+      expr(count, sources, query)
     end
 
     defp returning([], _verb),
@@ -702,6 +715,14 @@ if Code.ensure_loaded?(Tds.Connection) do
 
     def uuid(<<v1::32, v2::16, v3::16, v4::64>>) do
       <<v1::little-signed-32, v2::little-signed-16, v3::little-signed-16, v4::signed-64>>
+    end
+
+    defp error!(nil, message) do
+      raise ArgumentError, message
+    end
+
+    defp error!(query, message) do
+      raise Ecto.QueryError, query: query, message: message
     end
   end
 end

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -118,9 +118,8 @@ if Code.ensure_loaded?(Tds.Connection) do
 
       offset   = offset(query.offset, sources)
       # lock     = lock(query.lock)
-
       # unlock   = unlock(query.lock)
-
+      if (query.offset != nil and query.order_bys == []), do: raise(ArgumentError, "ORDER BY is mandatory to use OFFSET")
       assemble([select, from, join, where, group_by, having, order_by, offset])
     end
 
@@ -292,7 +291,7 @@ if Code.ensure_loaded?(Tds.Connection) do
 
     defp offset(nil, _sources), do: nil
     defp offset(%Ecto.Query.QueryExpr{expr: expr}, sources) do
-      "OFFSET " <> expr(expr, sources)
+      "OFFSET " <> expr(expr, sources) <> " ROW"
     end
 
     defp lock(nil), do: ""

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -407,6 +407,10 @@ if Code.ensure_loaded?(Tds.Connection) do
       "CONVERT(nvarchar(max), 0x#{hex})"
     end
 
+    defp expr(%Decimal{} = decimal, _sources) do
+      Decimal.to_string(decimal, :normal)
+    end
+
     defp expr(%Ecto.Query.Tagged{value: binary, type: :binary}, _sources) when is_binary(binary) do
       hex = Base.encode16(binary, case: :lower)
       "0x#{hex}"

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -38,7 +38,7 @@ if Code.ensure_loaded?(Tds.Connection) do
               us > 0 -> {{{y,m,d},{hh,mm,ss, us}}, :datetime2}
               true -> {{{y,m,d},{hh,mm,ss}}, :datetime}
             end
-          %Ecto.Query.Tagged{value: value, type: :uuid} ->
+          %Ecto.Query.Tagged{value: value, type: type} when type in [:binary_id, :uuid] ->
             cond do
               value == nil -> {nil, :binary}
               String.length(value) > 16 ->

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -336,6 +336,10 @@ if Code.ensure_loaded?(Tds.Connection) do
       expr(left, sources) <> " IN (" <> args <> ")"
     end
 
+    defp expr({:in, _, [left, right]}, sources) do
+      expr(left, sources) <> " = ANY(" <> expr(right, sources) <> ")"
+    end
+
     defp expr({:is_nil, _, [arg]}, sources) do
       "#{expr(arg, sources)} IS NULL"
     end

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -590,6 +590,7 @@ if Code.ensure_loaded?(Tds.Connection) do
         size            -> "#{type_name}(#{size})"
         precision       -> "#{type_name}(#{precision},#{scale || 0})"
         type == :string -> "nvarchar(255)"
+        type == :map    -> "nvarchar(max)"
         type == :text   -> "nvarchar(max)"
         type == :binary -> "varbinary(max)"
         type == :boolean -> "bit"
@@ -626,7 +627,7 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp ecto_to_db(:binary_id),  do: "uniqueidentifier"
     defp ecto_to_db(:string),     do: "nvarchar"
     defp ecto_to_db(:binary),     do: "varbinary"
-    defp ecto_to_db(:map),        do: "text"
+    defp ecto_to_db(:map),        do: "nvarchar"
     defp ecto_to_db(:boolean),    do: "bit"
     defp ecto_to_db(other),       do: Atom.to_string(other)
 

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -48,11 +48,10 @@ if Code.ensure_loaded?(Tds.Connection) do
           %Ecto.Query.Tagged{value: value, type: type} -> 
             {value, type}
           value -> 
-            {param(value), nil}
+            param(value)
         end
         {%Tds.Parameter{name: "@#{acc}", value: value, type: type}, acc + 1}
       end
-
       case Tds.Connection.query(conn, sql, params, opts) do
         {:ok, %Tds.Result{} = result} ->
 
@@ -62,12 +61,13 @@ if Code.ensure_loaded?(Tds.Connection) do
     end
 
     defp param(value) when is_binary(value) do
-      value
+      value = value
         |> :unicode.characters_to_binary(:utf8, {:utf16, :little})
+      {value, :string}
     end
-    defp param(value) when value == true, do: 1
-    defp param(value) when value == false, do: 0
-    defp param(value), do: value
+    defp param(value) when value == true, do: {1, :boolean}
+    defp param(value) when value == false, do: {0, :boolean}
+    defp param(value), do: {value, nil}
     ## Transaction
 
     def begin_transaction do

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -317,7 +317,12 @@ if Code.ensure_loaded?(Tds.Connection) do
     end
 
     defp expr({:&, _, [idx]}, sources) do
-      {_table, name, model} = elem(sources, idx)
+      {table, name, model} = elem(sources, idx)
+      unless model do
+        raise ArgumentError, "MSSQL requires a model when using selector #{inspect name} but " <>
+                             "only the table #{inspect table} was given. Please specify a model " <>
+                             "or specify exactly which fields from #{inspect name} you desire"
+      end
       fields = model.__schema__(:fields)
       Enum.map_join(fields, ", ", &"#{name}.#{quote_name(&1)}")
     end

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -130,7 +130,7 @@ if Code.ensure_loaded?(Tds.Connection) do
 
       update = "UPDATE #{name}"
       fields = update_fields(query.updates, sources)
-      from   = "FROM #{quote_table_name(table)} AS #{name}"
+      from   = "FROM #{table} AS #{name}"
       join   = join(query.joins, sources, query.lock)
       where  = where(query.wheres, sources)
 
@@ -142,27 +142,27 @@ if Code.ensure_loaded?(Tds.Connection) do
       {table, name, _model} = elem(sources, 0)
 
       delete = "DELETE #{name}"
-      from   = "FROM #{quote_table_name(table)} AS #{name}"
+      from   = "FROM #{table} AS #{name}"
       join   = join(query.joins, sources, query.lock)
       where  = where(query.wheres, sources)
 
       assemble([delete, from, join, where])
     end
 
-    def insert(table, fields, returning) do
+    def insert(prefix, table, fields, returning) do
       values =
         if fields == [] do
           returning(returning, "INSERTED") <>
           "DEFAULT VALUES"
         else
-          "(" <> Enum.map_join(fields, ", ", &quote_name/1) <> ") " <>
-          returning(returning, "INSERTED") <>
+          "(" <> Enum.map_join(fields, ", ", &quote_name/1) <> ")" <>
+          " " <> returning(returning, "INSERTED") <>
           "VALUES (" <> Enum.map_join(1..length(fields), ", ", &"@#{&1}") <> ")"
         end
-      "INSERT INTO #{quote_table_name(table)} " <> values
+      "INSERT INTO #{quote_table(prefix, table)} " <> values
     end
 
-    def update(table, fields, filters, returning) do
+    def update(prefix, table, fields, filters, returning) do
       {fields, count} = Enum.map_reduce fields, 1, fn field, acc ->
         {"#{quote_name(field)} = @#{acc}", acc + 1}
       end
@@ -170,17 +170,18 @@ if Code.ensure_loaded?(Tds.Connection) do
       {filters, _count} = Enum.map_reduce filters, count, fn field, acc ->
         {"#{quote_name(field)} = @#{acc}", acc + 1}
       end
-      "UPDATE #{quote_table_name(table)} SET " <> Enum.join(fields, ", ") <> returning(returning, "INSERTED") <>
-        " WHERE " <> Enum.join(filters, " AND ")
+      "UPDATE #{quote_table(prefix, table)} SET " <> Enum.join(fields, ", ") <>
+      " " <> returning(returning, "INSERTED") <>
+        "WHERE " <> Enum.join(filters, " AND ")
     end
 
-    def delete(table, filters, returning) do
+    def delete(prefix, table, filters, returning) do
       {filters, _} = Enum.map_reduce filters, 1, fn field, acc ->
         {"#{quote_name(field)} = @#{acc}", acc + 1}
       end
 
-      "DELETE FROM #{quote_table_name(table)}" <>
-      returning(returning,"DELETED") <> " WHERE " <> Enum.join(filters, " AND ")
+      "DELETE FROM #{quote_table(prefix, table)}" <>
+      " " <> returning(returning,"DELETED") <> "WHERE " <> Enum.join(filters, " AND ")
     end
 
     ## Query generation
@@ -219,7 +220,7 @@ if Code.ensure_loaded?(Tds.Connection) do
 
     defp from(sources, lock) do
       {table, name, _model} = elem(sources, 0)
-      "FROM #{quote_table_name(table)} AS #{name}" <> lock(lock) |> String.strip
+      "FROM #{table} AS #{name}" <> lock(lock) |> String.strip
     end
 
     defp update_fields(updates, sources) do
@@ -253,7 +254,7 @@ if Code.ensure_loaded?(Tds.Connection) do
           on   = expr(expr, sources)
           qual = join_qual(qual)
 
-          "#{qual} JOIN #{quote_table_name(table)} AS #{name} " <> lock(lock) <> "ON " <> on
+          "#{qual} JOIN #{table} AS #{name} " <> lock(lock) <> "ON " <> on
       end)
     end
 
@@ -452,15 +453,7 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp returning([], _verb),
       do: ""
     defp returning(returning, verb) do
-      " OUTPUT " <> Enum.map_join(returning, ", ", fn(arg) -> "#{verb}.#{quote_name(arg)} " end)
-    end
-
-    defp create_names(query) do
-      sources = query.sources |> Tuple.to_list
-      Enum.reduce(sources, [], fn {table, model}, names ->
-        name = unique_name(names, String.first(table), 0)
-        [{table, name, model}|names]
-      end) |> Enum.reverse |> List.to_tuple
+      "OUTPUT " <> Enum.map_join(returning, ", ", fn(arg) -> "#{verb}.#{quote_name(arg)}" end) <> " "
     end
 
     # Brute force find unique name
@@ -471,6 +464,21 @@ if Code.ensure_loaded?(Tds.Connection) do
       else
         counted_name
       end
+    end
+
+    defp create_names(%{prefix: prefix, sources: sources}) do
+      create_names(prefix, sources, 0, tuple_size(sources)) |> List.to_tuple()
+    end
+
+    defp create_names(prefix, sources, pos, limit) when pos < limit do
+      {table, model} = elem(sources, pos)
+      name = String.first(table) <> Integer.to_string(pos)
+      [{quote_table(prefix, table), name, model}|
+        create_names(prefix, sources, pos + 1, limit)]
+    end
+
+    defp create_names(_prefix, _sources, pos, pos) do
+      []
     end
 
     # DDL
@@ -500,23 +508,23 @@ if Code.ensure_loaded?(Tds.Connection) do
       end)
       unique_constraints = unique_columns
         |> Enum.map_join(", ", &unique_expr/1)
-      "CREATE TABLE #{quote_table_name(table.name)} (#{column_definitions(columns)}" <>
+      "CREATE TABLE #{quote_name(table.name)} (#{column_definitions(columns)}" <>
       if length(unique_columns) > 0, do: ", #{unique_constraints})", else: ")" <>
       options
     end
 
     def execute_ddl({:drop, %Table{name: name}}, _repo) do
-      "DROP TABLE #{quote_table_name(name)}"
+      "DROP TABLE #{quote_name(name)}"
     end
 
     def execute_ddl({:alter, %Table{}=table, changes}, _repo) do
       Enum.map_join(changes, "; ", fn(change) ->
-        "ALTER TABLE #{quote_table_name(table.name)} #{column_change(change)}"
+        "ALTER TABLE #{quote_name(table.name)} #{column_change(change)}"
       end)
     end
 
     def execute_ddl({:rename, %Table{}=current_table, %Table{}=new_table}, _repo) do
-      "EXEC sp_rename #{quote_table_name(current_table.name)}, #{quote_table_name(new_table.name)}"
+      "EXEC sp_rename #{quote_name(current_table.name)}, #{quote_name(new_table.name)}"
     end
 
     def execute_ddl({:create, %Index{}=index}, repo) do
@@ -528,13 +536,13 @@ if Code.ensure_loaded?(Tds.Connection) do
         ""
       end
       assemble(["CREATE#{if index.unique, do: " UNIQUE"} INDEX",
-                quote_table_name(index.name), " ON ", quote_table_name(index.table),
+                quote_name(index.name), " ON ", quote_name(index.table),
                 " (#{Enum.map_join(index.columns, ", ", &index_expr/1)})",
                 filter])
     end
 
     def execute_ddl({:drop, %Index{}=index}, _repo) do
-      assemble(["DROP INDEX", quote_table_name(index.name), " ON ", quote_table_name(index.table)])
+      assemble(["DROP INDEX", quote_name(index.name), " ON ", quote_name(index.table)])
     end
 
     def execute_ddl(default, _repo) when is_binary(default), do: default
@@ -579,7 +587,7 @@ if Code.ensure_loaded?(Tds.Connection) do
       raise "UNIQUE Indexes are not allowed on string types"
     end
     defp unique_expr({name, _type}) when is_atom(name) do
-      "CONSTRAINT uc_#{name} UNIQUE (#{quote_table_name(name)})"
+      "CONSTRAINT uc_#{name} UNIQUE (#{quote_name(name)})"
     end
     defp unique_expr(_), do: ""
 
@@ -648,14 +656,17 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp reference_on_delete(_), do: ""
 
     ## Helpers
+    defp quote_table(nil, name),
+      do: quote_name(name)
 
-    defp quote_name(name), do: "[#{name}]"
-    defp quote_table_name(name) do
-      "#{name}"
-        |> String.split(".")
-        |> Enum.map(&quote_name/1)
-        |> Enum.join(".")
-    end
+    defp quote_table(prefix, name),
+      do: quote_name(prefix) <> "." <> quote_name(name)
+
+    defp quote_name(name) when is_atom(name),
+      do: quote_name(Atom.to_string(name))
+
+    defp quote_name(name),
+      do: "[#{name}]"
 
     defp assemble(list) do
       list

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -2,8 +2,6 @@ if Code.ensure_loaded?(Tds.Connection) do
   defmodule Tds.Ecto.Connection do
     @moduledoc false
 
-    require Logger
-
     @default_port System.get_env("MSSQL_PORT") || 1433
     @behaviour Ecto.Adapters.SQL.Connection
 
@@ -34,7 +32,6 @@ if Code.ensure_loaded?(Tds.Connection) do
           %Ecto.Query.Tagged{value: value, type: type} -> 
             {value, type}
           value -> 
-            Logger.debug "Param: #{inspect param}"
             {param(value), nil}
         end
         {%Tds.Parameter{name: "@#{acc}", value: value, type: type}, acc + 1}
@@ -376,7 +373,6 @@ if Code.ensure_loaded?(Tds.Connection) do
     end
 
     defp expr(%Ecto.Query.Tagged{value: binary, type: :uuid}, _sources) when is_binary(binary) do
-      Logger.debug "UUID Tagged"
       <<
        p1::binary-size(1),
        p2::binary-size(1), 

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -583,8 +583,10 @@ if Code.ensure_loaded?(Tds.Connection) do
 
     defp column_type(%Reference{} = ref, opts) do
       "#{reference_column_type(ref.type, opts)} FOREIGN KEY REFERENCES " <>
-      "#{quote_name(ref.table)}(#{quote_name(ref.column)})"
+      "#{quote_name(ref.table)}(#{quote_name(ref.column)})" <>
+      reference_on_delete(ref.on_delete)
     end
+
     defp column_type({:array, _type}, _opts),
       do: raise "Array column type is not supported for MSSQL"
     defp column_type(:uuid, _opts), do: "uniqueidentifier"
@@ -613,6 +615,10 @@ if Code.ensure_loaded?(Tds.Connection) do
 
     defp reference_column_type(:serial, _opts), do: "bigint"
     defp reference_column_type(type, opts), do: column_type(type, opts)
+
+    defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
+    defp reference_on_delete(:delete_all), do: " ON DELETE CASCADE"
+    defp reference_on_delete(_), do: ""
 
     ## Helpers
 

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -48,8 +48,8 @@ if Code.ensure_loaded?(Tds.Connection) do
             end
           %Ecto.Query.Tagged{value: value, type: type} ->
             {value, type}
-          %{__struct__: _} = value -> {value, nil}
-          %{} = value -> {json_library.encode!(value), nil}
+          %{__struct__: _} = value -> {value, :string}
+          %{} = value -> {json_library.encode!(value), :string}
           value ->
             param(value)
         end

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -3,7 +3,8 @@ if Code.ensure_loaded?(Tds.Connection) do
     @moduledoc false
 
     @default_port System.get_env("MSSQLPORT") || 1433
-    @behaviour Ecto.Adapters.Worker
+
+    @behaviour Ecto.Adapters.Connection
     @behaviour Ecto.Adapters.SQL.Query
 
     def connect(opts) do

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -27,8 +27,13 @@ if Code.ensure_loaded?(Tds.Connection) do
           %Ecto.Query.Tagged{value: value, type: :binary} -> 
             value = if value == "", do: nil, else: value
             {value, :binary}
-          %Ecto.Query.Tagged{value: value, type: :uuid} -> 
-            {value, :string}
+          %Ecto.Query.Tagged{value: value, type: :uuid} ->
+            cond do
+              String.contains?(value, "-") -> 
+                {:ok, value} = Ecto.UUID.load(value)
+                {value, :string}
+              true -> {value, :binary}
+            end
           %Ecto.Query.Tagged{value: value, type: type} -> 
             {value, type}
           value -> 

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -551,7 +551,11 @@ if Code.ensure_loaded?(Tds.Connection) do
     end
 
     def execute_ddl({:rename, %Table{}=current_table, %Table{}=new_table}, _repo) do
-      "EXEC sp_rename #{quote_name(current_table.name)}, #{quote_name(new_table.name)}"
+      "EXEC sp_rename '#{current_table.name}', '#{new_table.name}'"
+    end
+
+    def execute_ddl({:rename, %Table{}=current_table, current_column, new_column}, _repo) do
+      "EXEC sp_rename '#{current_table.name}.#{current_column}', '#{new_column}', 'COLUMN'"
     end
 
     def execute_ddl({:create, %Index{}=index}, repo) do

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -54,7 +54,6 @@ if Code.ensure_loaded?(Tds.Connection) do
       end
       case Tds.Connection.query(conn, sql, params, opts) do
         {:ok, %Tds.Result{} = result} ->
-
           {:ok, Map.from_struct(result)}
         {:error, %Tds.Error{}} = err  -> err
       end
@@ -63,7 +62,7 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp param(value) when is_binary(value) do
       value = value
         |> :unicode.characters_to_binary(:utf8, {:utf16, :little})
-      {value, :string}
+      {value, :binary}
     end
     defp param(value) when value == true, do: {1, :boolean}
     defp param(value) when value == false, do: {0, :boolean}

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -62,7 +62,7 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp param(value) when is_binary(value) do
       value = value
         |> :unicode.characters_to_binary(:utf8, {:utf16, :little})
-      {value, :binary}
+      {value, nil}
     end
     defp param(value) when value == true, do: {1, :boolean}
     defp param(value) when value == false, do: {0, :boolean}

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -69,6 +69,8 @@ if Code.ensure_loaded?(Tds.Connection) do
         val -> {val, nil}
       end
     end
+
+    defp param({_,_,_} = value), do: {value, :date}
     defp param(value) when value == true, do: {1, :boolean}
     defp param(value) when value == false, do: {0, :boolean}
     defp param(value), do: {value, nil}
@@ -382,6 +384,16 @@ if Code.ensure_loaded?(Tds.Connection) do
         {:raw, part}  -> part
         {:expr, expr} -> expr(expr, sources)
       end)
+    end
+
+    defp expr({:datetime_add, _, [datetime, count, interval]}, sources, query) do
+      "CAST(DATEADD(" <> interval <> ", " <> count <> ", " <> expr(date, sources, query) <>
+        ", " <> ") AS datetime)"
+    end
+
+    defp expr({:date_add, _, [date, count, interval]}, sources, query) do
+      "CAST(DATEADD(" <> interval <> ", " <> count <> ", " <> expr(date, sources, query) <>
+        ", " <> ") AS date)"
     end
 
     defp expr({fun, _, args}, sources) when is_atom(fun) and is_list(args) do

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -515,6 +515,10 @@ if Code.ensure_loaded?(Tds.Connection) do
       end)
     end
 
+    def execute_ddl({:rename, %Table{}=current_table, %Table{}=new_table}, _repo) do
+      "EXEC sp_rename #{quote_table_name(current_table.name)}, #{quote_table_name(new_table.name)}"
+    end
+
     def execute_ddl({:create, %Index{}=index}, repo) do
 
       filter =

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -48,6 +48,8 @@ if Code.ensure_loaded?(Tds.Connection) do
             end
           %Ecto.Query.Tagged{value: value, type: type} ->
             {value, type}
+          %{__struct__: _} = value -> {value, nil}
+          %{} = value -> {json_library.encode!(value), nil}
           value ->
             param(value)
         end
@@ -68,6 +70,11 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp param(value) when value == true, do: {1, :boolean}
     defp param(value) when value == false, do: {0, :boolean}
     defp param(value), do: {value, nil}
+
+    defp json_library do
+      Application.get_env(:ecto, :json_library)
+    end
+
     ## Transaction
 
     def begin_transaction do
@@ -608,6 +615,7 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp ecto_to_db(:binary_id),  do: "uniqueidentifier"
     defp ecto_to_db(:string),     do: "nvarchar"
     defp ecto_to_db(:binary),     do: "varbinary"
+    defp ecto_to_db(:map),        do: "text"
     defp ecto_to_db(:boolean),    do: "bit"
     defp ecto_to_db(other),       do: Atom.to_string(other)
 

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -40,7 +40,7 @@ if Code.ensure_loaded?(Tds.Connection) do
           %Ecto.Query.Tagged{value: value, type: :uuid} ->
             cond do
               value == nil -> {nil, :binary}
-              String.contains?(value, "-") ->
+              String.length(value) > 16 ->
                 {:ok, value} = Ecto.UUID.cast(value)
                 {value, :string}
               true ->

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -224,7 +224,7 @@ if Code.ensure_loaded?(Tds.Connection) do
           on   = expr(expr, sources)
           qual = join_qual(qual)
 
-          "#{qual} JOIN #{quote_name(table)} AS #{name} " <> lock <> " ON " <> on
+          "#{qual} JOIN #{quote_name(table)} AS #{name} " <> lock(lock) <> " ON " <> on
       end)
     end
 

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -394,7 +394,7 @@ if Code.ensure_loaded?(Tds.Connection) do
     end
 
     defp expr(%Ecto.Query.Tagged{value: other, type: type}, sources) do
-      "CAST(#{expr(other, sources)} AS #{ecto_to_db(type)})"
+      "CAST(#{expr(other, sources)} AS #{column_type(type, [])})"
     end
 
     defp expr(nil, _sources),   do: "NULL"

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -627,30 +627,13 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp ecto_to_db(:binary_id),  do: "uniqueidentifier"
     defp ecto_to_db(:string),     do: "nvarchar"
     defp ecto_to_db(:binary),     do: "varbinary"
+    defp ecto_to_db(:datetime),   do: "datetime2"
     defp ecto_to_db(:map),        do: "nvarchar"
     defp ecto_to_db(:boolean),    do: "bit"
     defp ecto_to_db(other),       do: Atom.to_string(other)
 
-    defp uuid(binary) do
-      <<
-       p1::binary-size(1),
-       p2::binary-size(1),
-       p3::binary-size(1),
-       p4::binary-size(1),
-       p5::binary-size(1),
-       p6::binary-size(1),
-       p7::binary-size(1),
-       p8::binary-size(1),
-       p9::binary-size(1),
-       p10::binary-size(1),
-       p11::binary-size(1),
-       p12::binary-size(1),
-       p13::binary-size(1),
-       p14::binary-size(1),
-       p15::binary-size(1),
-       p16::binary-size(1)>> = binary
-
-       p4 <> p3 <> p2 <>p1 <> p6 <> p5 <> p8 <> p7 <> p9 <> p10 <> p11 <> p12 <> p13 <> p14 <> p15 <> p16
+    def uuid(<<v1::32, v2::16, v3::16, v4::64>>) do
+      <<v1::little-signed-32, v2::little-signed-16, v3::little-signed-16, v4::signed-64>>
     end
   end
 end

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -393,8 +393,8 @@ if Code.ensure_loaded?(Tds.Connection) do
       uuid(binary)
     end
 
-    defp expr(%Ecto.Query.Tagged{value: other}, sources) do
-      expr(other, sources)
+    defp expr(%Ecto.Query.Tagged{value: other, type: type}, sources) do
+      "CAST(#{expr(other, sources)} AS #{ecto_to_db(type)})"
     end
 
     defp expr(nil, _sources),   do: "NULL"

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -342,7 +342,7 @@ if Code.ensure_loaded?(Tds.Connection) do
     end
 
     defp expr({:in, _, [left, right]}, sources) do
-      expr(left, sources) <> " = ANY(" <> expr(right, sources) <> ")"
+      expr(left, sources) <> " IN (" <> expr(right, sources) <> ")"
     end
 
     defp expr({:is_nil, _, [arg]}, sources) do

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -2,6 +2,8 @@ if Code.ensure_loaded?(Tds.Connection) do
   defmodule Tds.Ecto.Connection do
     @moduledoc false
 
+    require Logger
+
     @default_port System.get_env("MSSQL_PORT") || 1433
     @behaviour Ecto.Adapters.SQL.Connection
 
@@ -27,9 +29,12 @@ if Code.ensure_loaded?(Tds.Connection) do
           %Ecto.Query.Tagged{value: value, type: :binary} -> 
             value = if value == "", do: nil, else: value
             {value, :binary}
+          %Ecto.Query.Tagged{value: value, type: :uuid} -> 
+            {value, :string}
           %Ecto.Query.Tagged{value: value, type: type} -> 
-              {value, type}
+            {value, type}
           value -> 
+            Logger.debug "Param: #{inspect param}"
             {param(value), nil}
         end
         {%Tds.Parameter{name: "@#{acc}", value: value, type: type}, acc + 1}
@@ -371,6 +376,7 @@ if Code.ensure_loaded?(Tds.Connection) do
     end
 
     defp expr(%Ecto.Query.Tagged{value: binary, type: :uuid}, _sources) when is_binary(binary) do
+      Logger.debug "UUID Tagged"
       <<
        p1::binary-size(1),
        p2::binary-size(1), 

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -159,12 +159,12 @@ if Code.ensure_loaded?(Tds.Connection) do
       "INSERT INTO #{quote_name(table)} " <> values
     end
 
-    def update(table, filters, fields, returning) do
-      {filters, count} = Enum.map_reduce filters, 1, fn field, acc ->
+    def update(table, fields, filters, returning) do
+      {fields, count} = Enum.map_reduce fields, 1, fn field, acc ->
         {"#{quote_name(field)} = @#{acc}", acc + 1}
       end
 
-      {fields, _count} = Enum.map_reduce fields, count, fn field, acc ->
+      {filters, _count} = Enum.map_reduce filters, count, fn field, acc ->
         {"#{quote_name(field)} = @#{acc}", acc + 1}
       end
       "UPDATE #{quote_name(table)} SET " <> Enum.join(fields, ", ") <> returning(returning, "INSERTED") <>

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -204,8 +204,8 @@ if Code.ensure_loaded?(Tds.Connection) do
     defp distinct(nil, _sources), do: ""
     defp distinct(%QueryExpr{expr: true}, _sources),  do: "DISTINCT "
     defp distinct(%QueryExpr{expr: false}, _sources), do: ""
-    defp distinct(%QueryExpr{expr: exprs}, sources) when is_list(exprs) do
-      "DISTINCT " <> Enum.map_join(exprs, ", ", &expr(&1, sources)) <> ""
+    defp distinct(%QueryExpr{expr: exprs}, sources) do
+      raise "MSSQL does not allow expressions in distinct"
     end
 
     defp from(sources, lock) do

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -608,7 +608,7 @@ if Code.ensure_loaded?(Tds.Connection) do
 
     defp column_change(table, {:add, name, %Reference{} = ref, opts}) do
       assemble([
-        "ADD COLUMN", quote_name(name), reference_column_type(ref.type, opts), column_options(opts),
+        "ADD", quote_name(name), reference_column_type(ref.type, opts), column_options(opts),
         reference_expr(ref, table, name)
       ])
     end

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -48,7 +48,7 @@ if Code.ensure_loaded?(Tds.Connection) do
             end
           %Ecto.Query.Tagged{value: value, type: type} ->
             {value, type}
-          %{__struct__: _} = value -> {value, :string}
+          %{__struct__: _} = value -> {value, nil}
           %{} = value -> {json_library.encode!(value), :string}
           value ->
             param(value)

--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -604,6 +604,8 @@ if Code.ensure_loaded?(Tds.Connection) do
       :binary.replace(value, "'", "''", [:global])
     end
 
+    defp ecto_to_db(:id),         do: "integer"
+    defp ecto_to_db(:binary_id),  do: "uniqueidentifier"
     defp ecto_to_db(:string),     do: "nvarchar"
     defp ecto_to_db(:binary),     do: "varbinary"
     defp ecto_to_db(:boolean),    do: "bit"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.0",
       deps: deps,
       description: description,

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TDS.Ecto.Mixfile do
 
   def project do
     [app: :tds_ecto,
-     version: "0.1.4",
+     version: "0.1.5-dev",
      elixir: "~> 1.0",
      deps: deps(Mix.env)]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.5.0",
+      version: "0.6.0",
       elixir: "~> 1.0",
       deps: deps,
       description: description,
@@ -21,8 +21,8 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 0.15.0"},
-      #{:ecto, github: "elixir-lang/ecto"},
+      #{:ecto, "~> 0.15.0"},
+      {:ecto, github: "elixir-lang/ecto"},
       {:tds, "~> 0.5.1"},
       {:poison, only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.2.5",
+      version: "0.2.6-dev",
       elixir: "~> 1.0",
       deps: deps,
       description: description,

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule TDS.Ecto.Mixfile do
   defp deps do
     [
       {:ecto, "~> 0.13.0"},
-      {:tds, "~> 0.3"},
+      {:tds, "~> 0.4"},
       {:poison, only: :test}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
-
+      {:poison, only: :test}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,9 +4,9 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.3.0-dev",
+      version: "0.2.5",
       elixir: "~> 1.0",
-      deps: deps(Mix.env),
+      deps: deps,
       description: description,
       package: package
    ]
@@ -21,25 +21,11 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
+      {:ecto, "~> 0.12.1"},
+      {:tds, "~> 0.2"},
       {:poison, only: :test}
     ]
   end
-
-  defp deps(:test) do
-    [
-      {:ecto, "~> 0.12.0"},
-      {:tds, path: "../tds"}
-    ] ++ deps
-  end
-
-  defp deps(_) do
-    [
-      {:ecto, "~> 0.12.0"},
-      {:tds, "~> 0.2"}
-    ] ++ deps
-  end
-
-
 
   defp description do
     """

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,9 @@ defmodule TDS.Ecto.Mixfile do
   end
 
   defp description do
-    "TDS Adapter for Ecto."
+    """
+    MSSQL / TDS Adapter for Ecto.
+    """
   end
 
   defp package do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TDS.Ecto.Mixfile do
 
   def project do
     [app: :tds_ecto,
-     version: "0.1.1",
+     version: "0.1.2-dev",
      elixir: "~> 1.0",
      deps: deps(Mix.env)]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps(:prod) do
     [
-      {:ecto, github: "elixir-lang/ecto"},
+      {:ecto, "~> 0.9"},
       {:tds, "~> 0.1"}
     ]
   end
@@ -29,7 +29,7 @@ defmodule TDS.Ecto.Mixfile do
   defp deps(_) do
     [
       {:ecto, github: "elixir-lang/ecto"},
-      {:tds, path: "../tds"}
+      {:tds, github: "livehelpnow/tds"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.2.4",
+      version: "0.3.0-dev",
       elixir: "~> 1.0",
       deps: deps(Mix.env),
       description: description,
@@ -34,7 +34,7 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps(_) do
     [
-      {:ecto, "~> 0.12.0-rc"},
+      {:ecto, "~> 0.12.0"},
       {:tds, "~> 0.2"}
     ] ++ deps
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.3.1",
+      version: "0.3.2",
       elixir: "~> 1.0",
       deps: deps,
       description: description,
@@ -22,7 +22,7 @@ defmodule TDS.Ecto.Mixfile do
   defp deps do
     [
       {:ecto, "~> 0.13.0"},
-      {:tds, "~> 0.4"},
+      {:tds, "~> 0.4.0"},
       {:poison, only: :test}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -14,18 +14,10 @@ defmodule TDS.Ecto.Mixfile do
   def application do
     [applications: [:logger]]
   end
-  
-  # Type `mix help deps` for more examples and options
-  defp deps do
-    [
-      {:ecto, git: "https://github.com/elixir-lang/ecto"},
-      {:tds, "~> 0.1"}
-    ]
-  end
 
   defp deps(:prod) do
     [
-      {:ecto, "~> 0.7"},
+      {:ecto, "~> 0.8"},
       {:tds, "~> 0.1"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TDS.Ecto.Mixfile do
 
   def project do
     [app: :tds_ecto,
-     version: "0.1.5",
+     version: "0.1.6-dev",
      elixir: "~> 1.0",
      deps: deps(Mix.env)]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.2.6-dev",
+      version: "0.3.0",
       elixir: "~> 1.0",
       deps: deps,
       description: description,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.6.0",
+      version: "1.0.0",
       elixir: "~> 1.0",
       deps: deps,
       description: description,
@@ -21,7 +21,7 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 0.16.0"},
+      {:ecto, "~> 1.0.0"},
       {:tds, "~> 0.5.1"},
       {:poison, only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -21,8 +21,8 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 0.12.1"},
-      {:tds, "~> 0.2"},
+      {:ecto, "~> 0.13.0"},
+      {:tds, "~> 0.3"},
       {:poison, only: :test}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.4.0",
+      version: "0.5.0",
       elixir: "~> 1.0",
       deps: deps,
       description: description,
@@ -21,8 +21,8 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
-      #{:ecto, "~> 0.14.1"},
-      {:ecto, github: "elixir-lang/ecto"},
+      {:ecto, "~> 0.15.0"},
+      #{:ecto, github: "elixir-lang/ecto"},
       {:tds, "~> 0.5.1"},
       {:poison, only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.2.1-dev",
+      version: "0.2.2",
       elixir: "~> 1.0",
       deps: deps(Mix.env),
       description: description,
@@ -21,7 +21,7 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps(:prod) do
     [
-      {:ecto, "~> 0.9"},
+      {:ecto, "~> 0.10"},
       {:tds, "~> 0.2"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 0.14.1"},
+      #{:ecto, "~> 0.14.1"},
+      {:ecto, github: "elixir-lang/ecto"},
       {:tds, "~> 0.5.1"},
       {:poison, only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TDS.Ecto.Mixfile do
 
   def project do
     [app: :tds_ecto,
-     version: "0.1.3",
+     version: "0.1.4",
      elixir: "~> 1.0",
      deps: deps(Mix.env)]
   end
@@ -12,7 +12,7 @@ defmodule TDS.Ecto.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:tds]]
   end
 
   defp deps(:prod) do

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 0.13.0"},
+      #{:ecto, "~> 0.13.0"},
+      {:ecto, github: "elixir-lang/ecto"},
       {:tds, "~> 0.3"},
       {:poison, only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.0",
       deps: deps,
       description: description,
@@ -21,9 +21,8 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
-      #{:ecto, "~> 0.13.0"},
-      {:ecto, github: "elixir-lang/ecto"},
-      {:tds, "~> 0.5.0"},
+      {:ecto, "~> 0.14.1"},
+      {:tds, "~> 0.5.1"},
       {:poison, only: :test}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps(:prod) do
     [
-      {:ecto, "~> 0.8"},
+      {:ecto, github: "elixir-lang/ecto"},
       {:tds, "~> 0.1"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.1.6-dev",
+      version: "0.2.0-dev",
       elixir: "~> 1.0",
       deps: deps(Mix.env),
       description: description,
@@ -29,7 +29,7 @@ defmodule TDS.Ecto.Mixfile do
   defp deps(_) do
     [
       {:ecto, github: "elixir-lang/ecto"},
-      {:tds, github: "livehelpnow/tds"}
+      {:tds, path: "../tds"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TDS.Ecto.Mixfile do
 
   def project do
     [app: :tds_ecto,
-     version: "0.1.2-dev",
+     version: "0.1.2",
      elixir: "~> 1.0",
      deps: deps(Mix.env)]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.2.2",
+      version: "0.2.3",
       elixir: "~> 1.0",
       deps: deps(Mix.env),
       description: description,

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TDS.Ecto.Mixfile do
 
   def project do
     [app: :tds_ecto,
-     version: "0.1.2",
+     version: "0.1.3",
      elixir: "~> 1.0",
      deps: deps(Mix.env)]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.2.0-dev",
+      version: "0.2.0",
       elixir: "~> 1.0",
       deps: deps(Mix.env),
       description: description,

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule TDS.Ecto.Mixfile do
     [
       #{:ecto, "~> 0.13.0"},
       {:ecto, github: "elixir-lang/ecto"},
-      {:tds, "~> 0.3"},
+      {:tds, "~> 0.5.0"},
       {:poison, only: :test}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.2.0",
+      version: "0.2.1-dev",
       elixir: "~> 1.0",
       deps: deps(Mix.env),
       description: description,

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule TDS.Ecto.Mixfile do
   defp deps(:prod) do
     [
       {:ecto, "~> 0.9"},
-      {:tds, "~> 0.1"}
+      {:tds, "~> 0.2"}
     ]
   end
  

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TDS.Ecto.Mixfile do
 
   def project do
     [app: :tds_ecto,
-     version: "0.0.2-dev",
+     version: "0.1.0",
      elixir: "~> 1.0",
      deps: deps(Mix.env)]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -27,8 +27,8 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps(:test) do
     [
-      {:ecto, "~> 0.12.0-rc"},
-      {:tds, github: "livehelpnow/tds"}
+      {:ecto, "~> 0.12.0"},
+      {:tds, path: "../tds"}
     ] ++ deps
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TDS.Ecto.Mixfile do
 
   def project do
     [app: :tds_ecto,
-     version: "0.1.0",
+     version: "0.1.1",
      elixir: "~> 1.0",
      deps: deps(Mix.env)]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,8 +21,7 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
-      #{:ecto, "~> 0.15.0"},
-      {:ecto, github: "elixir-lang/ecto"},
+      {:ecto, "~> 0.16.0"},
       {:tds, "~> 0.5.1"},
       {:poison, only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -2,17 +2,21 @@ defmodule TDS.Ecto.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :tds_ecto,
-     version: "0.1.6-dev",
-     elixir: "~> 1.0",
-     deps: deps(Mix.env)]
+    [
+      app: :tds_ecto,
+      version: "0.1.6-dev",
+      elixir: "~> 1.0",
+      deps: deps(Mix.env),
+      description: description,
+      package: package
+   ]
   end
 
   # Configuration for the OTP application
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:tds]]
+    [applications: [:tds, :ecto]]
   end
 
   defp deps(:prod) do
@@ -27,5 +31,15 @@ defmodule TDS.Ecto.Mixfile do
       {:ecto, github: "elixir-lang/ecto"},
       {:tds, github: "livehelpnow/tds"}
     ]
+  end
+
+  defp description do
+    "TDS Adapter for Ecto."
+  end
+
+  defp package do
+    [contributors: ["Justin Schneck"],
+     licenses: ["Apache 2.0"],
+     links: %{"Github" => "https://github.com/livehelpnow/tds_ecto"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,25 +21,25 @@ defmodule TDS.Ecto.Mixfile do
 
   defp deps do
     [
-      
+
     ]
   end
 
   defp deps(:test) do
     [
-      {:ecto, github: "elixir-lang/ecto"},
+      {:ecto, "~> 0.12.0-rc"},
       {:tds, github: "livehelpnow/tds"}
     ] ++ deps
   end
 
   defp deps(_) do
     [
-      {:ecto, "~> 0.11"},
+      {:ecto, "~> 0.12.0-rc"},
       {:tds, "~> 0.2"}
     ] ++ deps
   end
 
-  
+
 
   defp description do
     """

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TDS.Ecto.Mixfile do
 
   def project do
     [app: :tds_ecto,
-     version: "0.1.5-dev",
+     version: "0.1.5",
      elixir: "~> 1.0",
      deps: deps(Mix.env)]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TDS.Ecto.Mixfile do
   def project do
     [
       app: :tds_ecto,
-      version: "0.2.3",
+      version: "0.2.4",
       elixir: "~> 1.0",
       deps: deps(Mix.env),
       description: description,
@@ -19,19 +19,27 @@ defmodule TDS.Ecto.Mixfile do
     [applications: [:tds, :ecto]]
   end
 
-  defp deps(:prod) do
+  defp deps do
     [
-      {:ecto, "~> 0.10"},
-      {:tds, "~> 0.2"}
+      
     ]
   end
- 
-  defp deps(_) do
+
+  defp deps(:test) do
     [
       {:ecto, github: "elixir-lang/ecto"},
       {:tds, github: "livehelpnow/tds"}
-    ]
+    ] ++ deps
   end
+
+  defp deps(_) do
+    [
+      {:ecto, "~> 0.11"},
+      {:tds, "~> 0.2"}
+    ] ++ deps
+  end
+
+  
 
   defp description do
     """

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "4d2713e739f7b7a0a5a8bb85a237796ae8a2c8c9", []},
+  "ecto": {:hex, :ecto, "0.14.1"},
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:hex, :tds, "0.5.0"},
+  "tds": {:hex, :tds, "0.5.1"},
   "timex": {:hex, :timex, "0.14.3"},
   "tzdata": {:hex, :tzdata, "0.1.6"}}

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,6 @@
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:hex, :tds, "0.3.0"},
+  "tds": {:hex, :tds, "0.4.0"},
   "timex": {:hex, :timex, "0.14.3"},
   "tzdata": {:hex, :tzdata, "0.1.6"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "a22c5ddd4cbd551b11635fe48f3d51e56afce806", []},
+  "ecto": {:hex, :ecto, "0.15.0"},
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,6 @@
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:hex, :tds, "0.2.7"},
+  "tds": {:hex, :tds, "0.2.8"},
   "timex": {:hex, :timex, "0.14.3"},
   "tzdata": {:hex, :tzdata, "0.1.6"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.14.1"},
+  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "a22c5ddd4cbd551b11635fe48f3d51e56afce806", []},
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "930f2185566abce8ac6528beccee2f35687a48f4", []},
+  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "dba5c808178b14955a38ddfd33a4bc6728097a33", []},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
   "tds": {:git, "git://github.com/livehelpnow/tds.git", "4ee78e59fd1ff74db756b7b4f31054f5635612a8", []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.12.1"},
+  "ecto": {:hex, :ecto, "0.13.0"},
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:hex, :tds, "0.2.8"},
+  "tds": {:hex, :tds, "0.3.0"},
   "timex": {:hex, :timex, "0.14.3"},
   "tzdata": {:hex, :tzdata, "0.1.6"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.10.0"},
+  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "930f2185566abce8ac6528beccee2f35687a48f4", []},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:hex, :tds, "0.2.3"},
-  "timex": {:hex, :timex, "0.12.9"}}
+  "tds": {:git, "git://github.com/livehelpnow/tds.git", "72f9982e840319d572f171923c2a3393c0c4edba", []},
+  "timex": {:hex, :timex, "0.13.4"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "4ac0c64c4d30ee8bcc659818fb61acc2050b2b4b", []},
+  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "cec98ded972dfbb8230020695204409f0974b4cc", []},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
   "tds": {:git, "git://github.com/livehelpnow/tds.git", "7f075889828eddb3638b8678bc8372d0b666daa5", []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "b7d9f62207caea3a754848a0d979537a83edb6eb", []},
+  "ecto": {:hex, :ecto, "0.10.0"},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:git, "git://github.com/livehelpnow/tds.git", "7734e938ceb6719e2f7fa4f6af0848aace0627a9", []},
+  "tds": {:hex, :tds, "0.2.3"},
   "timex": {:hex, :timex, "0.12.9"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "3e054c061d06b807d2006f06fa94e6ab5dca8ee1", []},
+  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "b7d9f62207caea3a754848a0d979537a83edb6eb", []},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:git, "git://github.com/livehelpnow/tds.git", "41d12c877553f016ac6f31671decd0d63dff69b7", []},
+  "tds": {:git, "git://github.com/livehelpnow/tds.git", "94ef46d38dbd2eef1f84d4546e31425e13db15c6", []},
   "timex": {:hex, :timex, "0.12.9"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "16f27f64c5ca2480568fad10e40c26522ffbf793", []},
+  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "4d2713e739f7b7a0a5a8bb85a237796ae8a2c8c9", []},
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:hex, :tds, "0.3.0"},
+  "tds": {:hex, :tds, "0.5.0"},
   "timex": {:hex, :timex, "0.14.3"},
   "tzdata": {:hex, :tzdata, "0.1.6"}}

--- a/mix.lock
+++ b/mix.lock
@@ -2,5 +2,5 @@
   "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "930f2185566abce8ac6528beccee2f35687a48f4", []},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:git, "git://github.com/livehelpnow/tds.git", "72f9982e840319d572f171923c2a3393c0c4edba", []},
+  "tds": {:git, "git://github.com/livehelpnow/tds.git", "4ee78e59fd1ff74db756b7b4f31054f5635612a8", []},
   "timex": {:hex, :timex, "0.13.4"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.12.0-rc"},
+  "ecto": {:hex, :ecto, "0.12.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
   "tds": {:git, "git://github.com/livehelpnow/tds.git", "709be57e1127adeaf4307d396ecda2a87877cd11", []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.13.0"},
+  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "16f27f64c5ca2480568fad10e40c26522ffbf793", []},
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "b5a5e246a73a5e1d7c109e74844a81ce7a197fbf", []},
+  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "4ac0c64c4d30ee8bcc659818fb61acc2050b2b4b", []},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:git, "git://github.com/livehelpnow/tds.git", "b2a3b64f276eefee5929738b11fd001e353e13f7", []},
+  "tds": {:git, "git://github.com/livehelpnow/tds.git", "7f075889828eddb3638b8678bc8372d0b666daa5", []},
   "timex": {:hex, :timex, "0.12.9"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.15.0"},
+  "ecto": {:hex, :ecto, "0.16.0"},
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.12.0"},
+  "ecto": {:hex, :ecto, "0.12.1"},
+  "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:git, "git://github.com/livehelpnow/tds.git", "709be57e1127adeaf4307d396ecda2a87877cd11", []},
-  "timex": {:hex, :timex, "0.13.4"}}
+  "tds": {:hex, :tds, "0.2.7"},
+  "timex": {:hex, :timex, "0.14.3"},
+  "tzdata": {:hex, :tzdata, "0.1.6"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.16.0"},
-  "poison": {:hex, :poison, "1.4.0"},
+  "ecto": {:hex, :ecto, "1.0.0"},
+  "poison": {:hex, :poison, "1.5.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
   "tds": {:hex, :tds, "0.5.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "dba5c808178b14955a38ddfd33a4bc6728097a33", []},
-  "poolboy": {:hex, :poolboy, "1.4.2"},
+  "ecto": {:hex, :ecto, "0.12.0-rc"},
+  "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:git, "git://github.com/livehelpnow/tds.git", "4ee78e59fd1ff74db756b7b4f31054f5635612a8", []},
+  "tds": {:git, "git://github.com/livehelpnow/tds.git", "709be57e1127adeaf4307d396ecda2a87877cd11", []},
   "timex": {:hex, :timex, "0.13.4"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "cec98ded972dfbb8230020695204409f0974b4cc", []},
+  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "3e054c061d06b807d2006f06fa94e6ab5dca8ee1", []},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:git, "git://github.com/livehelpnow/tds.git", "7f075889828eddb3638b8678bc8372d0b666daa5", []},
+  "tds": {:git, "git://github.com/livehelpnow/tds.git", "41d12c877553f016ac6f31671decd0d63dff69b7", []},
   "timex": {:hex, :timex, "0.12.9"}}

--- a/mix.lock
+++ b/mix.lock
@@ -2,5 +2,5 @@
   "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "b7d9f62207caea3a754848a0d979537a83edb6eb", []},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.7.0"},
-  "tds": {:git, "git://github.com/livehelpnow/tds.git", "94ef46d38dbd2eef1f84d4546e31425e13db15c6", []},
+  "tds": {:git, "git://github.com/livehelpnow/tds.git", "7734e938ceb6719e2f7fa4f6af0848aace0627a9", []},
   "timex": {:hex, :timex, "0.12.9"}}

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -32,7 +32,7 @@ defmodule Tds.Ecto.StorageTest do
         # Execute the query
         case Ecto.Adapters.Mssql.Connection.query(pid, sql_command, [], []) do
           {:ok, %{}} -> {:ok, 0}
-          {_, %Tds.Error{message: message, mssql: error}} ->
+          {_, %Tds.Error{mssql: error}} ->
             {error, 1}
         end
       {_, error} -> 

--- a/test/tds_ecto_test.exs
+++ b/test/tds_ecto_test.exs
@@ -1,7 +1,4 @@
 defmodule TDS.EctoTest do
   use ExUnit.Case
 
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
 end

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -170,10 +170,10 @@ defmodule Tds.Ecto.TdsTest do
     query = Model |> select([r], fragment("lower(?)", ^value)) |> normalize
     assert SQL.all(query) == ~s{SELECT lower(@1) FROM [model] AS m0}
 
-    # query = Model |> select([], fragment(title: 2)) |> normalize
-    # assert_raise ArgumentError, fn ->
-    #   SQL.all(query)
-    # end
+    query = Model |> select([], fragment(title: 2)) |> normalize
+    assert_raise ArgumentError, fn ->
+      SQL.all(query)
+    end
   end
 
   test "literals" do

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -402,7 +402,7 @@ defmodule Tds.Ecto.TdsTest do
 
   # DDL
 
-  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3, references: 1]
+  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3, references: 1, references: 2]
 
   test "executing a string during migration" do
     assert SQL.execute_ddl("example") == "example"
@@ -424,6 +424,29 @@ defmodule Tds.Ecto.TdsTest do
     assert SQL.execute_ddl(create) ==
            ~s|CREATE TABLE [posts] ([id] bigint NOT NULL PRIMARY KEY IDENTITY, [category_id] bigint FOREIGN KEY REFERENCES [categories]([id]) NULL)|
   end
+
+  test "create table with reference and on_delete: :nothing clause" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :category_id, references(:categories, on_delete: :nothing), []} ]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE [posts] ([id] bigint NOT NULL PRIMARY KEY IDENTITY, [category_id] bigint FOREIGN KEY REFERENCES [categories]([id]) NULL)|
+  end
+
+  test "create table with reference and on_delete: :nilify_all clause" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :category_id, references(:categories, on_delete: :nilify_all), []} ]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE [posts] ([id] bigint NOT NULL PRIMARY KEY IDENTITY, [category_id] bigint FOREIGN KEY REFERENCES [categories]([id]) ON DELETE SET NULL NULL)|
+  end
+
+  test "create table with reference and on_delete: :delete_all clause" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :category_id, references(:categories, on_delete: :delete_all), []} ]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE [posts] ([id] bigint NOT NULL PRIMARY KEY IDENTITY, [category_id] bigint FOREIGN KEY REFERENCES [categories]([id]) ON DELETE CASCADE NULL)|  end
 
   test "create table with column options" do
     create = {:create, table(:posts),

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -2,27 +2,496 @@ Code.require_file "../deps/ecto/integration_test/support/types.exs", __DIR__
 
 defmodule Tds.Ecto.TdsTest do
   use ExUnit.Case, async: true
-  use Ecto.Migration
-  
+
+  import Ecto.Query
+
+  alias Ecto.Queryable
   alias Tds.Ecto.Connection, as: SQL
+
+  defmodule Model do
+    use Ecto.Model
+
+    schema "model" do
+      field :x, :integer
+      field :y, :integer
+
+      has_many :comments, Tds.Ecto.TdsTest.Model2,
+        references: :x,
+        foreign_key: :z
+      has_one :permalink, Tds.Ecto.TdsTest.Model3,
+        references: :y,
+        foreign_key: :id
+    end
+  end
+
+  defmodule Model2 do
+    use Ecto.Model
+
+    schema "model2" do
+      belongs_to :post, Tds.Ecto.TdsTest.Model,
+        references: :x,
+        foreign_key: :z
+    end
+  end
+
+  defmodule Model3 do
+    use Ecto.Model
+
+    schema "model3" do
+      field :binary, :binary
+    end
+  end
+
+  defp normalize(query) do
+    {query, _params} = Ecto.Query.Planner.prepare(query, [], %{})
+    Ecto.Query.Planner.normalize(query, [], [])
+  end
+
+  test "from" do
+    query = Model |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0}
+  end
+
+  test "from without model" do
+    query = "posts" |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT p0.[x] FROM [posts] AS p0}
+  end
+
+  test "from with schema source" do
+    query = "public.posts" |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT p0.[x] FROM [public].[posts] AS p0}
+  end
+
+  test "select" do
+    query = Model |> select([r], {r.x, r.y}) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x], m0.[y] FROM [model] AS m0}
+
+    query = Model |> select([r], [r.x, r.y]) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x], m0.[y] FROM [model] AS m0}
+  end
+
+  test "distinct" do
+    query = Model |> distinct([r], true) |> select([r], {r.x, r.y}) |> normalize
+    assert SQL.all(query) == ~s{SELECT DISTINCT m0.[x], m0.[y] FROM [model] AS m0}
+
+    query = Model |> distinct([r], false) |> select([r], {r.x, r.y}) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x], m0.[y] FROM [model] AS m0}
+
+    query = Model |> distinct(true) |> select([r], {r.x, r.y}) |> normalize
+    assert SQL.all(query) == ~s{SELECT DISTINCT m0.[x], m0.[y] FROM [model] AS m0}
+
+    query = Model |> distinct(false) |> select([r], {r.x, r.y}) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x], m0.[y] FROM [model] AS m0}
+
+    assert_raise ArgumentError, "MSSQL does not allow expressions in distinct", fn ->
+      query = Model |> distinct([r], [r.x, r.y]) |> select([r], {r.x, r.y}) |> normalize
+      SQL.all(query)
+    end
+  end
+
+  test "where" do
+    query = Model |> where([r], r.x == 42) |> where([r], r.y != 43) |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 WHERE (m0.[x] = 42) AND (m0.[y] != 43)}
+  end
+
+  test "order by" do
+    query = Model |> order_by([r], r.x) |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 ORDER BY m0.[x]}
+
+    query = Model |> order_by([r], [r.x, r.y]) |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 ORDER BY m0.[x], m0.[y]}
+
+    query = Model |> order_by([r], [asc: r.x, desc: r.y]) |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 ORDER BY m0.[x], m0.[y] DESC}
+
+    query = Model |> order_by([r], []) |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0}
+  end
+
+  test "limit and offset" do
+    query = Model |> limit([r], 3) |> select([], 0) |> normalize
+    assert SQL.all(query) == ~s{SELECT TOP(3) 0 FROM [model] AS m0}
+
+    query = Model |> offset([r], 5) |> select([], 0) |> normalize
+    assert SQL.all(query) == ~s{SELECT 0 FROM [model] AS m0 OFFSET 5}
+
+    query = Model |> offset([r], 5) |> limit([r], 3) |> select([], 0) |> normalize
+    assert SQL.all(query) == ~s{SELECT TOP(3) 0 FROM [model] AS m0 OFFSET 5}
+  end
+
+  test "lock" do
+    query = Model |> lock("WITH(NOLOCK)") |> select([], 0) |> normalize
+    assert SQL.all(query) == ~s{SELECT 0 FROM [model] AS m0 WITH(NOLOCK)}
+  end
+
+  # TODO
+  # These need to be updated
+  # test "string escape" do
+  #   query = Model |> select([], "'\\  ") |> normalize
+  #   assert SQL.all(query) == ~s{SELECT '''\\\\  ' FROM [model] AS m0}
+
+  #   query = Model |> select([], "'") |> normalize
+  #   assert SQL.all(query) == ~s{SELECT '''' FROM [model] AS m0}
+  # end
+
+  test "binary ops" do
+    query = Model |> select([r], r.x == 2) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] = 2 FROM [model] AS m0}
+
+    query = Model |> select([r], r.x != 2) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] != 2 FROM [model] AS m0}
+
+    query = Model |> select([r], r.x <= 2) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] <= 2 FROM [model] AS m0}
+
+    query = Model |> select([r], r.x >= 2) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] >= 2 FROM [model] AS m0}
+
+    query = Model |> select([r], r.x < 2) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] < 2 FROM [model] AS m0}
+
+    query = Model |> select([r], r.x > 2) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] > 2 FROM [model] AS m0}
+  end
+
+  test "is_nil" do
+    query = Model |> select([r], is_nil(r.x)) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] IS NULL FROM [model] AS m0}
+
+    query = Model |> select([r], not is_nil(r.x)) |> normalize
+    assert SQL.all(query) == ~s{SELECT NOT (m0.[x] IS NULL) FROM [model] AS m0}
+  end
+
+  test "fragments" do
+    query = Model |> select([r], fragment("lower(?)", r.x)) |> normalize
+    assert SQL.all(query) == ~s{SELECT lower(m0.[x]) FROM [model] AS m0}
+
+    value = 13
+    query = Model |> select([r], fragment("lower(?)", ^value)) |> normalize
+    assert SQL.all(query) == ~s{SELECT lower(@1) FROM [model] AS m0}
+
+    # query = Model |> select([], fragment(title: 2)) |> normalize
+    # assert_raise ArgumentError, fn ->
+    #   SQL.all(query)
+    # end
+  end
+
+  test "literals" do
+    query = Model |> select([], nil) |> normalize
+    assert SQL.all(query) == ~s{SELECT NULL FROM [model] AS m0}
+
+    query = Model |> select([], true) |> normalize
+    assert SQL.all(query) == ~s{SELECT 1 FROM [model] AS m0}
+
+    query = Model |> select([], false) |> normalize
+    assert SQL.all(query) == ~s{SELECT 0 FROM [model] AS m0}
+
+    # query = Model |> select([], "abc") |> normalize
+    # assert SQL.all(query) == ~s{SELECT 'abc' FROM [model] AS m0}
+
+    query = Model |> select([], 123) |> normalize
+    assert SQL.all(query) == ~s{SELECT 123 FROM [model] AS m0}
+
+    query = Model |> select([], 123.0) |> normalize
+    assert SQL.all(query) == ~s{SELECT 123.0 FROM [model] AS m0}
+  end
+
+  # test "tagged type" do
+  #   query = Model |> select([], type(^"601d74e4-a8d3-4b6e-8365-eddb4c893327", Ecto.UUID)) |> normalize
+  #   assert SQL.all(query) == ~s{SELECT CAST(? AS uniqueidentifier) FROM [model] AS m0}
+  # end
+
+  test "nested expressions" do
+    z = 123
+    query = from(r in Model, []) |> select([r], r.x > 0 and (r.y > ^(-z)) or true) |> normalize
+    assert SQL.all(query) == ~s{SELECT ((m0.[x] > 0) AND (m0.[y] > @1)) OR 1 FROM [model] AS m0}
+  end
+
+  test "in expression" do
+    query = Model |> select([e], 1 in []) |> normalize
+    assert SQL.all(query) == ~s{SELECT 0=1 FROM [model] AS m0}
+
+    query = Model |> select([e], 1 in [1,e.x,3]) |> normalize
+    assert SQL.all(query) == ~s{SELECT 1 IN (1,m0.[x],3) FROM [model] AS m0}
+
+    query = Model |> select([e], 1 in ^[]) |> normalize
+    assert SQL.all(query) == ~s{SELECT 0=1 FROM [model] AS m0}
+
+    query = Model |> select([e], 1 in ^[1, 2, 3]) |> normalize
+    assert SQL.all(query) == ~s{SELECT 1 IN (@1,@2,@3) FROM [model] AS m0}
+
+    query = Model |> select([e], 1 in [1, ^2, 3]) |> normalize
+    assert SQL.all(query) == ~s{SELECT 1 IN (1,@1,3) FROM [model] AS m0}
+  end
+
+  test "having" do
+    query = Model |> having([p], p.x == p.x) |> select([p], p.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 HAVING (m0.[x] = m0.[x])}
+
+    query = Model |> having([p], p.x == p.x) |> having([p], p.y == p.y) |> select([p], [p.y, p.x]) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[y], m0.[x] FROM [model] AS m0 HAVING (m0.[x] = m0.[x]) AND (m0.[y] = m0.[y])}
+  end
+
+  test "group by" do
+    query = Model |> group_by([r], r.x) |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 GROUP BY m0.[x]}
+
+    query = Model |> group_by([r], 2) |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 GROUP BY 2}
+
+    query = Model |> group_by([r], [r.x, r.y]) |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 GROUP BY m0.[x], m0.[y]}
+
+    query = Model |> group_by([r], []) |> select([r], r.x) |> normalize
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0}
+  end
+
+  test "interpolated values" do
+    query = Model
+            |> select([], ^0)
+            |> join(:inner, [], Model2, ^true)
+            |> join(:inner, [], Model2, ^false)
+            |> where([], ^true)
+            |> where([], ^false)
+            |> group_by([], ^1)
+            |> group_by([], ^2)
+            |> having([], ^true)
+            |> having([], ^false)
+            |> order_by([], fragment("?", ^3))
+            |> order_by([], ^:x)
+            |> limit([], ^4)
+            |> offset([], ^5)
+            |> normalize
+
+    result =
+      "SELECT TOP(@11) @1 FROM [model] AS m0 INNER JOIN [model2] AS m1 ON @2 " <>
+      "INNER JOIN [model2] AS m2 ON @3 WHERE (@4) AND (@5) " <>
+      "GROUP BY @6, @7 HAVING (@8) AND (@9) " <>
+      "ORDER BY @10, m0.[x] OFFSET @12"
+
+    assert SQL.all(query) == String.rstrip(result)
+  end
+
+  ## *_all
+
+  test "update all" do
+    query = Model |> Queryable.to_query |> normalize
+    assert SQL.update_all(query, [x: 0]) ==
+           ~s{UPDATE m0 SET m0.[x] = 0 FROM [model] AS m0}
+
+    query = from(e in Model, where: e.x == 123) |> normalize
+    assert SQL.update_all(query, [x: 0]) ==
+           ~s{UPDATE m0 SET m0.[x] = 0 FROM [model] AS m0 WHERE (m0.[x] = 123)}
+
+    # TODO
+    # query = Model |> Queryable.to_query |> normalize
+    # assert SQL.update_all(query, [x: 0, y: "123"]) ==
+    #        ~s{UPDATE m0 SET m0.[x] = 0, m0.[y] = '123' FROM [model] AS m0 }
+
+    query = Model |> Queryable.to_query |> normalize
+    assert SQL.update_all(query, [x: quote(do: ^0)]) ==
+           ~s{UPDATE m0 SET m0.[x] = @1 FROM [model] AS m0}
+
+    query = Model |> join(:inner, [p], q in Model2, p.x == q.z) |> normalize
+    assert SQL.update_all(query, [x: 0]) ==
+           ~s{UPDATE m0 SET m0.[x] = 0 FROM [model] AS m0 INNER JOIN [model2] AS m1 ON m0.[x] = m1.[z]}
+
+    query = from(e in Model, where: e.x == 123, join: q in Model2, on: e.x == q.z) |> normalize
+    assert SQL.update_all(query, [x: 0]) ==
+           ~s{UPDATE m0 SET m0.[x] = 0 FROM [model] AS m0 INNER JOIN [model2] AS m1 ON m0.[x] = m1.[z] WHERE (m0.[x] = 123)}
+  end
+
+  test "delete all" do
+    query = Model |> Queryable.to_query |> normalize
+    assert SQL.delete_all(query) == ~s{DELETE m0 FROM [model] AS m0}
+
+    query = from(e in Model, where: e.x == 123) |> normalize
+    assert SQL.delete_all(query) ==
+           ~s{DELETE m0 FROM [model] AS m0 WHERE (m0.[x] = 123)}
+
+    query = Model |> join(:inner, [p], q in Model2, p.x == q.z) |> normalize
+    assert SQL.delete_all(query) ==
+           ~s{DELETE m0 FROM [model] AS m0 INNER JOIN [model2] AS m1 ON m0.[x] = m1.[z]}
+
+    query = from(e in Model, where: e.x == 123, join: q in Model2, on: e.x == q.z) |> normalize
+    assert SQL.delete_all(query) ==
+           ~s{DELETE m0 FROM [model] AS m0 } <>
+           ~s{INNER JOIN [model2] AS m1 ON m0.[x] = m1.[z] WHERE (m0.[x] = 123)}
+  end
+
+  ## Joins
+
+  test "join" do
+    query = Model |> join(:inner, [p], q in Model2, p.x == q.z) |> select([], 0) |> normalize
+    assert SQL.all(query) ==
+           ~s{SELECT 0 FROM [model] AS m0 INNER JOIN [model2] AS m1 ON m0.[x] = m1.[z]}
+
+    query = Model |> join(:inner, [p], q in Model2, p.x == q.z)
+                  |> join(:inner, [], Model, true) |> select([], 0) |> normalize
+    assert SQL.all(query) ==
+           ~s{SELECT 0 FROM [model] AS m0 INNER JOIN [model2] AS m1 ON m0.[x] = m1.[z] } <>
+           ~s{INNER JOIN [model] AS m2 ON 1}
+  end
+
+  test "join with nothing bound" do
+    query = Model |> join(:inner, [], q in Model2, q.z == q.z) |> select([], 0) |> normalize
+    assert SQL.all(query) ==
+           ~s{SELECT 0 FROM [model] AS m0 INNER JOIN [model2] AS m1 ON m1.[z] = m1.[z]}
+  end
+
+  test "join without model" do
+    query = "posts" |> join(:inner, [p], q in "comments", p.x == q.z) |> select([], 0) |> normalize
+    assert SQL.all(query) ==
+           ~s{SELECT 0 FROM [posts] AS p0 INNER JOIN [comments] AS c0 ON p0.[x] = c0.[z]}
+  end
+
+  ## Associations
+
+  test "association join belongs_to" do
+    query = Model2 |> join(:inner, [c], p in assoc(c, :post)) |> select([], 0) |> normalize
+    assert SQL.all(query) ==
+           "SELECT 0 FROM [model2] AS m0 INNER JOIN [model] AS m1 ON m1.[x] = m0.[z]"
+  end
+
+  test "association join has_many" do
+    query = Model |> join(:inner, [p], c in assoc(p, :comments)) |> select([], 0) |> normalize
+    assert SQL.all(query) ==
+           "SELECT 0 FROM [model] AS m0 INNER JOIN [model2] AS m1 ON m1.[z] = m0.[x]"
+  end
+
+  test "association join has_one" do
+    query = Model |> join(:inner, [p], pp in assoc(p, :permalink)) |> select([], 0) |> normalize
+    assert SQL.all(query) ==
+           "SELECT 0 FROM [model] AS m0 INNER JOIN [model3] AS m1 ON m1.[id] = m0.[y]"
+  end
+
+  test "join produces correct bindings" do
+    query = from(p in Model, join: c in Model2, on: true)
+    query = from(p in query, join: c in Model2, on: true, select: {p.id, c.id})
+    query = normalize(query)
+    assert SQL.all(query) ==
+           "SELECT m0.[id], m2.[id] FROM [model] AS m0 INNER JOIN [model2] AS m1 ON 1 INNER JOIN [model2] AS m2 ON 1"
+  end
+
+  # Model based
+
+  test "insert" do
+    query = SQL.insert("model", [:x, :y], [])
+    assert query == ~s{INSERT INTO [model] ([x], [y]) VALUES (@1, @2)}
+
+    query = SQL.insert("model", [], [])
+    assert query == ~s{INSERT INTO [model] DEFAULT VALUES}
+  end
+
+  test "update" do
+    query = SQL.update("model", [:id], [:x, :y], [])
+    assert query == ~s{UPDATE [model] SET [id] = @1 WHERE [x] = @2 AND [y] = @3}
+  end
+
+  test "delete" do
+    query = SQL.delete("model", [:x, :y], [])
+    assert query == ~s{DELETE FROM [model] WHERE [x] = @1 AND [y] = @2}
+  end
+
+  # DDL
+
+  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3, references: 1]
+
+  test "executing a string during migration" do
+    assert SQL.execute_ddl("example") == "example"
+  end
+
+  test "create table" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :title, :string, []},
+                {:add, :created_at, :datetime, []}]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE [posts] ([id] bigint NOT NULL PRIMARY KEY IDENTITY, [title] nvarchar(255) NULL, [created_at] datetime NULL)|
+  end
+
+  test "create table with reference" do
+    create = {:create, table(:posts),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :category_id, references(:categories), []} ]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE [posts] ([id] bigint NOT NULL PRIMARY KEY IDENTITY, [category_id] bigint FOREIGN KEY REFERENCES [categories]([id]) NULL)|
+  end
 
   test "create table with column options" do
     create = {:create, table(:posts),
                [{:add, :name, :string, [default: "Untitled", size: 20, null: false]},
-                {:add, :price, :decimal, [unique: true, precision: 15, scale: 14, default: {:fragment, "PI()"}]},
+                {:add, :price, :numeric, [precision: 8, scale: 2, default: {:fragment, "expr"}]},
                 {:add, :on_hand, :integer, [default: 0, null: true]},
-                {:add, :is_active, :boolean, [default: true]},
-                {:add, :slug, :text, [null: false]}]}
-                
-    assert SQL.execute_ddl(create, nil) == """
+                {:add, :is_active, :boolean, [default: true]}]}
+
+    assert SQL.execute_ddl(create) == """
     CREATE TABLE [posts] ([name] nvarchar(20) DEFAULT 'Untitled' NOT NULL,
-    [price] decimal(15,14) DEFAULT PI() NULL,
+    [price] numeric(8,2) DEFAULT expr NULL,
     [on_hand] integer DEFAULT 0 NULL,
-    [is_active] bit DEFAULT 1 NULL,
-    [slug] nvarchar(max) NOT NULL,
-    CONSTRAINT uc_price UNIQUE ([price]))
+    [is_active] bit DEFAULT 1 NULL)
     """ |> String.strip |> String.replace("\n", " ")
   end
+
+  test "drop table" do
+    drop = {:drop, table(:posts)}
+    assert SQL.execute_ddl(drop) == ~s|DROP TABLE [posts]|
+  end
+
+  test "alter table" do
+    alter = {:alter, table(:posts),
+               [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},
+                {:modify, :price, :numeric, [precision: 8, scale: 2]},
+                {:remove, :summary}]}
+
+    assert SQL.execute_ddl(alter) == """
+    ALTER TABLE [posts]
+    ADD [title] nvarchar(100) DEFAULT 'Untitled' NOT NULL;
+    ALTER TABLE [posts]
+    ALTER COLUMN [price] numeric(8,2) NULL;
+    ALTER TABLE [posts]
+    DROP COLUMN [summary]
+    """ |> String.strip |> String.replace("\n", " ")
+  end
+
+  # test "create index" do
+  #   create = {:create, index(:posts, [:category_id, :permalink])}
+  #   assert SQL.execute_ddl(create) ==
+  #          ~s|CREATE INDEX [posts_category_id_permalink_index] ON [posts] ([category_id], [permalink])|
+
+  #   create = {:create, index(:posts, ["lower(permalink)"], name: "posts$main")}
+  #   assert SQL.execute_ddl(create) ==
+  #          ~s|CREATE INDEX [posts$main] ON [posts] ([lower(permalink)])|
+  # end
+
+  # test "create index asserting concurrency" do
+  #   create = {:create, index(:posts, ["lower(permalink)"], name: "posts$main", concurrently: true)}
+  #   assert SQL.execute_ddl(create) ==
+  #          ~s|CREATE INDEX `posts$main` ON `posts` (`lower(permalink)`) LOCK=NONE|
+  # end
+
+  # test "create unique index" do
+  #   create = {:create, index(:posts, [:permalink], unique: true)}
+  #   assert SQL.execute_ddl(create) ==
+  #          ~s|CREATE UNIQUE INDEX `posts_permalink_index` ON `posts` (`permalink`)|
+  # end
+
+  # test "create an index using a different type" do
+  #   create = {:create, index(:posts, [:permalink], using: :hash)}
+  #   assert SQL.execute_ddl(create) ==
+  #          ~s|CREATE INDEX `posts_permalink_index` ON `posts` (`permalink`) USING hash|
+  # end
+
+  # test "drop index" do
+  #   drop = {:drop, index(:posts, [:id], name: "posts$main")}
+  #   assert SQL.execute_ddl(drop) == ~s|DROP INDEX `posts$main` ON `posts`|
+  # end
+
+  # test "drop index asserting concurrency" do
+  #   drop = {:drop, index(:posts, [:id], name: "posts$main", concurrentlyrently: true)}
+  #   assert SQL.execute_ddl(drop) == ~s|DROP INDEX `posts$main` ON `posts` LOCK=NONE|
+  # end
+
 
 end
 

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -386,6 +386,18 @@ defmodule Tds.Ecto.TdsTest do
            ~s{SELECT 0 FROM [prefix].[model] AS m0 INNER JOIN [prefix].[model2] AS m1 ON m0.[x] = m1.[z]}
   end
 
+  test "join with fragment" do
+    query = Model
+            |> join(:inner, [p], q in fragment("SELECT * FROM model2 AS m2 WHERE m2.id = ? AND m2.field = ?", p.x, ^10))
+            |> select([p], {p.id, ^0})
+            |> where([p], p.id > 0 and p.id < ^100)
+            |> normalize
+    assert SQL.all(query) ==
+           ~s{SELECT m0.[id], @1 FROM [model] AS m0 INNER JOIN } <>
+           ~s{(SELECT * FROM model2 AS m2 WHERE m2.id = m0.[x] AND m2.field = @1) AS f1 ON 1 } <>
+           ~s{WHERE ((m0.[id] > 0) AND (m0.[id] < @3))}
+  end
+
   ## Associations
 
   test "association join belongs_to" do

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -461,6 +461,14 @@ defmodule Tds.Ecto.TdsTest do
     """ |> String.strip |> String.replace("\n", " ")
   end
 
+  test "create table with options" do
+    create = {:create, table(:posts, [options: "WITH FOO=BAR"]),
+               [{:add, :id, :serial, [primary_key: true]},
+                {:add, :created_at, :datetime, []}]}
+    assert SQL.execute_ddl(create) ==
+           ~s|CREATE TABLE [posts] ([id] bigint NOT NULL PRIMARY KEY IDENTITY, [created_at] datetime2 NULL) WITH FOO=BAR|
+  end
+
   # test "create index" do
   #   create = {:create, index(:posts, [:category_id, :permalink])}
   #   assert SQL.execute_ddl(create) ==

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -14,6 +14,8 @@ defmodule Tds.Ecto.TdsTest do
     schema "model" do
       field :x, :integer
       field :y, :integer
+      field :z, :integer
+      field :w, {:array, :integer}
 
       has_many :comments, Tds.Ecto.TdsTest.Model2,
         references: :x,
@@ -43,8 +45,8 @@ defmodule Tds.Ecto.TdsTest do
   end
 
   defp normalize(query, operation \\ :all) do
-    {query, _params} = Ecto.Query.Planner.prepare(query, operation, [], %{})
-    Ecto.Query.Planner.normalize(query, operation, [])
+    {query, _params} = Ecto.Query.Planner.prepare(query, operation, Tds.Ecto)
+    Ecto.Query.Planner.normalize(query, operation, Tds.Ecto)
   end
 
   test "from" do
@@ -60,11 +62,10 @@ defmodule Tds.Ecto.TdsTest do
       SQL.all from(p in "posts", select: p) |> normalize()
     end
   end
-
-  test "from with schema source" do
-    query = "public.posts" |> select([r], r.x) |> normalize
-    assert SQL.all(query) == ~s{SELECT p0.[x] FROM [public].[posts] AS p0}
-  end
+  # test "from with schema source" do
+  #   query = "public.posts" |> select([r], r.x) |> normalize
+  #   assert SQL.all(query) == ~s{SELECT p0.[x] FROM [public].[posts] AS p0}
+  # end
 
   test "select" do
     query = Model |> select([r], {r.x, r.y}) |> normalize
@@ -95,7 +96,7 @@ defmodule Tds.Ecto.TdsTest do
 
   test "where" do
     query = Model |> where([r], r.x == 42) |> where([r], r.y != 43) |> select([r], r.x) |> normalize
-    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 WHERE (m0.[y] != 43) AND (m0.[x] = 42)}
+    assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 WHERE (m0.[x] = 42) AND (m0.[y] != 43)}
   end
 
   test "order by" do
@@ -238,7 +239,7 @@ defmodule Tds.Ecto.TdsTest do
     assert SQL.all(query) == ~s{SELECT m0.[x] FROM [model] AS m0 HAVING (m0.[x] = m0.[x])}
 
     query = Model |> having([p], p.x == p.x) |> having([p], p.y == p.y) |> select([p], [p.y, p.x]) |> normalize
-    assert SQL.all(query) == ~s{SELECT m0.[y], m0.[x] FROM [model] AS m0 HAVING (m0.[y] = m0.[y]) AND (m0.[x] = m0.[x])}
+    assert SQL.all(query) == ~s{SELECT m0.[y], m0.[x] FROM [model] AS m0 HAVING (m0.[x] = m0.[x]) AND (m0.[y] = m0.[y])}
 
     query = Model |> select([e], 1 in fragment("foo")) |> normalize
     assert SQL.all(query) == ~s{SELECT 1 IN (foo) FROM [model] AS m0}
@@ -304,7 +305,7 @@ defmodule Tds.Ecto.TdsTest do
 
     query = from(m in Model, update: [set: [x: 0, y: "123"]]) |> normalize(:update_all)
     assert SQL.update_all(query) ==
-           ~s{UPDATE m0 SET m0.[x] = 0, m0.[y] = CONVERT(nvarchar(max), 0x310032003300) FROM [model] AS m0}
+           ~s{UPDATE m0 SET m0.[x] = 0, m0.[y] = 123 FROM [model] AS m0}
 
     query = from(m in Model, update: [set: [x: ^0]]) |> normalize(:update_all)
     assert SQL.update_all(query) ==
@@ -349,6 +350,12 @@ defmodule Tds.Ecto.TdsTest do
            ~s{UPDATE m0 SET m0.[x] = 0 FROM [model] AS m0 INNER JOIN [model2] AS m1 ON m0.[x] = m1.[z] WHERE (m0.[x] = 123)}
   end
 
+  test "update all with prefix" do
+    query = from(m in Model, update: [set: [x: 0]]) |> normalize(:update_all)
+    assert SQL.update_all(%{query | prefix: "prefix"}) ==
+           ~s{UPDATE m0 SET m0.[x] = 0 FROM [prefix].[model] AS m0}
+  end
+
   test "delete all" do
     query = Model |> Queryable.to_query |> normalize
     assert SQL.delete_all(query) == ~s{DELETE m0 FROM [model] AS m0}
@@ -366,6 +373,13 @@ defmodule Tds.Ecto.TdsTest do
            ~s{DELETE m0 FROM [model] AS m0 } <>
            ~s{INNER JOIN [model2] AS m1 ON m0.[x] = m1.[z] WHERE (m0.[x] = 123)}
   end
+
+  test "delete all with prefix" do
+    query = Model |> Queryable.to_query |> normalize
+    assert SQL.delete_all(%{query | prefix: "prefix"}) ==
+      ~s{DELETE m0 FROM [prefix].[model] AS m0}
+  end
+
 
   ## Joins
 
@@ -390,7 +404,13 @@ defmodule Tds.Ecto.TdsTest do
   test "join without model" do
     query = "posts" |> join(:inner, [p], q in "comments", p.x == q.z) |> select([], 0) |> normalize
     assert SQL.all(query) ==
-           ~s{SELECT 0 FROM [posts] AS p0 INNER JOIN [comments] AS c0 ON p0.[x] = c0.[z]}
+           ~s{SELECT 0 FROM [posts] AS p0 INNER JOIN [comments] AS c1 ON p0.[x] = c1.[z]}
+  end
+
+  test "join with prefix" do
+    query = Model |> join(:inner, [p], q in Model2, p.x == q.z) |> select([], 0) |> normalize
+    assert SQL.all(%{query | prefix: "prefix"}) ==
+           ~s{SELECT 0 FROM [prefix].[model] AS m0 INNER JOIN [prefix].[model2] AS m1 ON m0.[x] = m1.[z]}
   end
 
   ## Associations
@@ -424,21 +444,39 @@ defmodule Tds.Ecto.TdsTest do
   # Model based
 
   test "insert" do
-    query = SQL.insert("model", [:x, :y], [])
+    query = SQL.insert(nil, "model", [:x, :y], [])
     assert query == ~s{INSERT INTO [model] ([x], [y]) VALUES (@1, @2)}
 
-    query = SQL.insert("model", [], [])
+    query = SQL.insert(nil, "model", [], [:id])
+    assert query == ~s{INSERT INTO [model] OUTPUT INSERTED.[id] DEFAULT VALUES}
+
+    query = SQL.insert(nil, "model", [], [])
     assert query == ~s{INSERT INTO [model] DEFAULT VALUES}
+
+    query = SQL.insert("prefix", "model", [], [])
+    assert query == ~s{INSERT INTO [prefix].[model] DEFAULT VALUES}
   end
 
   test "update" do
-    query = SQL.update("model", [:id], [:x, :y], [])
+    query = SQL.update(nil, "model", [:id], [:x, :y], [])
     assert query == ~s{UPDATE [model] SET [id] = @1 WHERE [x] = @2 AND [y] = @3}
+
+    query = SQL.update(nil, "model", [:x, :y], [:id], [:z])
+    assert query == ~s{UPDATE [model] SET [x] = @1, [y] = @2 OUTPUT INSERTED.[z] WHERE [id] = @3}
+
+    query = SQL.update("prefix", "model", [:x, :y], [:id], [])
+    assert query == ~s{UPDATE [prefix].[model] SET [x] = @1, [y] = @2 WHERE [id] = @3}
   end
 
   test "delete" do
-    query = SQL.delete("model", [:x, :y], [])
+    query = SQL.delete(nil, "model", [:x, :y], [])
     assert query == ~s{DELETE FROM [model] WHERE [x] = @1 AND [y] = @2}
+
+    query = SQL.delete(nil, "model", [:x, :y], [:z])
+    assert query == ~s{DELETE FROM [model] OUTPUT DELETED.[z] WHERE [x] = @1 AND [y] = @2}
+
+    query = SQL.delete("prefix", "model", [:x, :y], [])
+    assert query == ~s{DELETE FROM [prefix].[model] WHERE [x] = @1 AND [y] = @2}
   end
 
   # DDL

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -60,7 +60,7 @@ defmodule Tds.Ecto.TdsTest do
                 {:add, :is_active, :boolean, [default: true]},
                 {:add, :slug, :text, [null: false]}]}
                 
-    assert SQL.execute_ddl(create) == """
+    assert SQL.execute_ddl(create, nil) == """
     CREATE TABLE [posts] ([name] nvarchar(20) DEFAULT 'Untitled' NOT NULL,
     [price] decimal(15,14) DEFAULT PI() NULL,
     [on_hand] integer DEFAULT 0 NULL,

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -234,6 +234,9 @@ defmodule Tds.Ecto.TdsTest do
 
     query = Model |> having([p], p.x == p.x) |> having([p], p.y == p.y) |> select([p], [p.y, p.x]) |> normalize
     assert SQL.all(query) == ~s{SELECT m0.[y], m0.[x] FROM [model] AS m0 HAVING (m0.[x] = m0.[x]) AND (m0.[y] = m0.[y])}
+
+    query = Model |> select([e], 1 in fragment("foo")) |> normalize
+    assert SQL.all(query) == ~s{SELECT 1 IN (foo) FROM [model] AS m0}
   end
 
   test "group by" do

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -394,7 +394,7 @@ defmodule Tds.Ecto.TdsTest do
             |> normalize
     assert SQL.all(query) ==
            ~s{SELECT m0.[id], @1 FROM [model] AS m0 INNER JOIN } <>
-           ~s{(SELECT * FROM model2 AS m2 WHERE m2.id = m0.[x] AND m2.field = @1) AS f1 ON 1 } <>
+           ~s{(SELECT * FROM model2 AS m2 WHERE m2.id = m0.[x] AND m2.field = @2) AS f1 ON 1 } <>
            ~s{WHERE ((m0.[id] > 0) AND (m0.[id] < @3))}
   end
 

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -1,0 +1,74 @@
+Code.require_file "../deps/ecto/test/support/types.exs", __DIR__
+
+defmodule Tds.Ecto.TdsTest do
+  use ExUnit.Case, async: true
+  use Ecto.Migration
+
+  import Ecto.Query
+  import Ecto
+  alias Tds.Ecto.Connection, as: SQL
+
+  alias Ecto.Queryable
+  alias Ecto.Query.Planner
+
+  defmodule Model do
+    use Ecto.Model
+
+    schema "model" do
+      field :x, :integer
+      field :y, :integer
+
+      has_many :comments, Ecto.Adapters.PostgresTest.Model2,
+        references: :x,
+        foreign_key: :z
+      has_one :permalink, Ecto.Adapters.PostgresTest.Model3,
+        references: :y,
+        foreign_key: :id
+    end
+  end
+
+  defmodule Model2 do
+    use Ecto.Model
+
+    schema "model2" do
+      belongs_to :post, Ecto.Adapters.PostgresTest.Model,
+        references: :x,
+        foreign_key: :z
+    end
+  end
+
+  defmodule Model3 do
+    use Ecto.Model
+
+    schema "model3" do
+      field :list1, {:array, :string}
+      field :list2, {:array, :integer}
+      field :binary, :binary
+    end
+  end
+
+  defp normalize(query) do
+    {query, _params} = Planner.prepare(query, %{})
+    Planner.normalize(query, %{}, [])
+  end
+
+  test "create table with column options" do
+    create = {:create, table(:posts),
+               [{:add, :name, :string, [default: "Untitled", size: 20, null: false]},
+                {:add, :price, :decimal, [unique: true, precision: 15, scale: 14, default: {:fragment, "PI()"}]},
+                {:add, :on_hand, :integer, [default: 0, null: true]},
+                {:add, :is_active, :boolean, [default: true]},
+                {:add, :slug, :text, [null: false]}]}
+
+    assert SQL.execute_ddl(create) == """
+    CREATE TABLE [posts] ([name] nvarchar(20) DEFAULT 'Untitled' NOT NULL,
+    [price] decimal(15,14) DEFAULT PI() NULL,
+    [on_hand] integer DEFAULT 0 NULL,
+    [is_active] bit DEFAULT 1 NULL,
+    [slug] nvarchar(max) NOT NULL,
+    CONSTRAINT uc_price UNIQUE ([price]))
+    """ |> String.strip |> String.replace("\n", " ")
+  end
+
+end
+

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -55,6 +55,10 @@ defmodule Tds.Ecto.TdsTest do
   test "from without model" do
     query = "posts" |> select([r], r.x) |> normalize
     assert SQL.all(query) == ~s{SELECT p0.[x] FROM [posts] AS p0}
+
+    assert_raise ArgumentError, ~r"MSSQL requires a model", fn ->
+      SQL.all from(p in "posts", select: p) |> normalize()
+    end
   end
 
   test "from with schema source" do

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -58,7 +58,7 @@ defmodule Tds.Ecto.TdsTest do
     query = "posts" |> select([r], r.x) |> normalize
     assert SQL.all(query) == ~s{SELECT p0.[x] FROM [posts] AS p0}
 
-    assert_raise ArgumentError, ~r"MSSQL requires a model", fn ->
+    assert_raise Ecto.QueryError, ~r"MSSQL requires a model", fn ->
       SQL.all from(p in "posts", select: p) |> normalize()
     end
   end
@@ -88,7 +88,7 @@ defmodule Tds.Ecto.TdsTest do
     query = Model |> distinct(false) |> select([r], {r.x, r.y}) |> normalize
     assert SQL.all(query) == ~s{SELECT m0.[x], m0.[y] FROM [model] AS m0}
 
-    assert_raise ArgumentError, "MSSQL does not allow expressions in distinct", fn ->
+    assert_raise Ecto.QueryError, ~r"MSSQL does not allow expressions in distinct", fn ->
       query = Model |> distinct([r], [r.x, r.y]) |> select([r], {r.x, r.y}) |> normalize
       SQL.all(query)
     end
@@ -124,7 +124,7 @@ defmodule Tds.Ecto.TdsTest do
     assert SQL.all(query) == ~s{SELECT TOP(3) 0 FROM [model] AS m0 ORDER BY m0.[x] OFFSET 5 ROW}
 
     query = Model |> offset([r], 5) |> limit([r], 3) |> select([], 0) |> normalize
-    assert_raise ArgumentError, fn ->
+    assert_raise Ecto.QueryError, fn ->
       SQL.all(query)
     end
   end

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -170,10 +170,10 @@ defmodule Tds.Ecto.TdsTest do
     query = Model |> select([r], fragment("lower(?)", ^value)) |> normalize
     assert SQL.all(query) == ~s{SELECT lower(@1) FROM [model] AS m0}
 
-    query = Model |> select([], fragment(title: 2)) |> normalize
-    assert_raise ArgumentError, fn ->
-      SQL.all(query)
-    end
+    # query = Model |> select([], fragment(title: 2)) |> normalize
+    # assert_raise ArgumentError, fn ->
+    #   SQL.all(query)
+    # end
   end
 
   test "literals" do

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "../deps/ecto/test/support/types.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/support/types.exs", __DIR__
 
 defmodule Tds.Ecto.TdsTest do
   use ExUnit.Case, async: true

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -59,7 +59,7 @@ defmodule Tds.Ecto.TdsTest do
                 {:add, :on_hand, :integer, [default: 0, null: true]},
                 {:add, :is_active, :boolean, [default: true]},
                 {:add, :slug, :text, [null: false]}]}
-
+                
     assert SQL.execute_ddl(create) == """
     CREATE TABLE [posts] ([name] nvarchar(20) DEFAULT 'Untitled' NOT NULL,
     [price] decimal(15,14) DEFAULT PI() NULL,

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -407,7 +407,7 @@ defmodule Tds.Ecto.TdsTest do
                 {:add, :title, :string, []},
                 {:add, :created_at, :datetime, []}]}
     assert SQL.execute_ddl(create) ==
-           ~s|CREATE TABLE [posts] ([id] bigint NOT NULL PRIMARY KEY IDENTITY, [title] nvarchar(255) NULL, [created_at] datetime NULL)|
+           ~s|CREATE TABLE [posts] ([id] bigint NOT NULL PRIMARY KEY IDENTITY, [title] nvarchar(255) NULL, [created_at] datetime2 NULL)|
   end
 
   test "create table with reference" do

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -112,11 +112,16 @@ defmodule Tds.Ecto.TdsTest do
     query = Model |> limit([r], 3) |> select([], 0) |> normalize
     assert SQL.all(query) == ~s{SELECT TOP(3) 0 FROM [model] AS m0}
 
-    query = Model |> offset([r], 5) |> select([], 0) |> normalize
-    assert SQL.all(query) == ~s{SELECT 0 FROM [model] AS m0 OFFSET 5}
+    query = Model |> order_by([r], r.x) |> offset([r], 5) |> select([], 0) |> normalize
+    assert SQL.all(query) == ~s{SELECT 0 FROM [model] AS m0 ORDER BY m0.[x] OFFSET 5 ROW}
+
+    query = Model |> order_by([r], r.x) |> offset([r], 5) |> limit([r], 3) |> select([], 0) |> normalize
+    assert SQL.all(query) == ~s{SELECT TOP(3) 0 FROM [model] AS m0 ORDER BY m0.[x] OFFSET 5 ROW}
 
     query = Model |> offset([r], 5) |> limit([r], 3) |> select([], 0) |> normalize
-    assert SQL.all(query) == ~s{SELECT TOP(3) 0 FROM [model] AS m0 OFFSET 5}
+    assert_raise ArgumentError, fn ->
+      SQL.all(query)
+    end
   end
 
   test "lock" do
@@ -267,7 +272,7 @@ defmodule Tds.Ecto.TdsTest do
       "SELECT TOP(@11) @1 FROM [model] AS m0 INNER JOIN [model2] AS m1 ON @2 " <>
       "INNER JOIN [model2] AS m2 ON @3 WHERE (@4) AND (@5) " <>
       "GROUP BY @6, @7 HAVING (@8) AND (@9) " <>
-      "ORDER BY @10, m0.[x] OFFSET @12"
+      "ORDER BY @10, m0.[x] OFFSET @12 ROW"
 
     assert SQL.all(query) == String.rstrip(result)
   end

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -533,6 +533,11 @@ defmodule Tds.Ecto.TdsTest do
            ~s|CREATE TABLE [posts] ([id] bigint NOT NULL PRIMARY KEY IDENTITY, [created_at] datetime2 NULL) WITH FOO=BAR|
   end
 
+  test "rename table" do
+    rename = {:rename, table(:posts), table(:new_posts)}
+    assert SQL.execute_ddl(rename) == ~s|EXEC sp_rename [posts], [new_posts]|
+  end
+
   # test "create index" do
   #   create = {:create, index(:posts, [:category_id, :permalink])}
   #   assert SQL.execute_ddl(create) ==

--- a/test/tds_test.exs
+++ b/test/tds_test.exs
@@ -3,54 +3,8 @@ Code.require_file "../deps/ecto/integration_test/support/types.exs", __DIR__
 defmodule Tds.Ecto.TdsTest do
   use ExUnit.Case, async: true
   use Ecto.Migration
-
-  import Ecto.Query
-  import Ecto
+  
   alias Tds.Ecto.Connection, as: SQL
-
-  alias Ecto.Queryable
-  alias Ecto.Query.Planner
-
-  defmodule Model do
-    use Ecto.Model
-
-    schema "model" do
-      field :x, :integer
-      field :y, :integer
-
-      has_many :comments, Ecto.Adapters.PostgresTest.Model2,
-        references: :x,
-        foreign_key: :z
-      has_one :permalink, Ecto.Adapters.PostgresTest.Model3,
-        references: :y,
-        foreign_key: :id
-    end
-  end
-
-  defmodule Model2 do
-    use Ecto.Model
-
-    schema "model2" do
-      belongs_to :post, Ecto.Adapters.PostgresTest.Model,
-        references: :x,
-        foreign_key: :z
-    end
-  end
-
-  defmodule Model3 do
-    use Ecto.Model
-
-    schema "model3" do
-      field :list1, {:array, :string}
-      field :list2, {:array, :integer}
-      field :binary, :binary
-    end
-  end
-
-  defp normalize(query) do
-    {query, _params} = Planner.prepare(query, %{})
-    Planner.normalize(query, %{}, [])
-  end
 
   test "create table with column options" do
     create = {:create, table(:posts),

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,10 @@
 Logger.configure(level: :info)
 ExUnit.start exclude: [:assigns_primary_key, :array_type, :case_sensitive]
 # Basic test repo
+Code.require_file "../deps/ecto/integration_test/support/repo.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/support/models.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/support/migration.exs", __DIR__
+
 alias Ecto.Integration.TestRepo
 
 Application.put_env(:ecto, TestRepo,
@@ -12,7 +16,7 @@ Application.put_env(:ecto, TestRepo,
   max_overflow: 0)
 
 defmodule Ecto.Integration.TestRepo do
-  use Ecto.Repo,
+  use Ecto.Integration.Repo,
     otp_app: :ecto
 end
 
@@ -27,7 +31,7 @@ Application.put_env(:ecto, PoolRepo,
   max_overflow: 0)
 
 defmodule Ecto.Integration.PoolRepo do
-  use Ecto.Repo,
+  use Ecto.Integration.Repo,
     otp_app: :ecto
 
     def lock_for_update, do: "WITH(UPDLOCK)"
@@ -62,20 +66,22 @@ defmodule Ecto.Integration.Case do
     #Ecto.Adapters.SQL.begin_test_transaction(TestRepo, [])
     Ecto.Adapters.SQL.restart_test_transaction(TestRepo, [])
     #on_exit fn -> Ecto.Adapters.SQL.rollback_test_transaction(TestRepo, []) end
-    :ok 
+    :ok
   end
 end
 
 
 :erlang.system_flag :backtrace_depth, 50
 # Load support models and migration
-Code.require_file "../deps/ecto/integration_test/support/models.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/support/migration.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/cases/lock.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/cases/migration.exs", __DIR__
+
+
+Code.require_file "../deps/ecto/integration_test/sql/lock.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/sql/migration.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/sql/escape.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/sql/transaction.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/repo.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/cases/type.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/preload.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/cases/sql_escape.exs", __DIR__
 
 
 # Load up the repository, start it, and run migrations

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,11 +1,12 @@
-System.at_exit fn _ -> Logger.flush end
-Logger.configure(level: :debug)
+#System.at_exit fn _ -> Logger.flush end
+Logger.configure(level: :info)
 ExUnit.start exclude: [:assigns_primary_key, :array_type, :case_sensitive]
 # Basic test repo
 alias Ecto.Integration.TestRepo
-require Logger
+
 Application.put_env(:ecto, TestRepo,
   adapter: Tds.Ecto,
+  filter_null_on_unique_indexes: true,
   url: "ecto://mssql:mssql@mssql.local/ecto_test",
   size: 1,
   max_overflow: 0)
@@ -20,6 +21,7 @@ alias Ecto.Integration.PoolRepo
 
 Application.put_env(:ecto, PoolRepo,
   adapter: Tds.Ecto,
+  filter_null_on_unique_indexes: true,
   url: "ecto://mssql:mssql@mssql.local/ecto_test",
   size: 10,
   max_overflow: 0)
@@ -83,4 +85,4 @@ _   = Ecto.Storage.down(TestRepo)
 {:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link
 
-:ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration)
+:ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -75,7 +75,6 @@ end
 :erlang.system_flag :backtrace_depth, 50
 # Load support models and migration
 
-
 Code.require_file "../deps/ecto/integration_test/sql/lock.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/sql/migration.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/sql/escape.exs", __DIR__

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,3 @@
-#System.at_exit fn _ -> Logger.flush end
 Logger.configure(level: :error)
 ExUnit.start exclude: [:assigns_id_type, :array_type, :case_sensitive]
 
@@ -82,7 +81,6 @@ end
 Code.require_file "../deps/ecto/integration_test/sql/lock.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/sql/migration.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/sql/escape.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/sql/transaction.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/repo.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/type.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/preload.exs", __DIR__

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,10 @@
 #System.at_exit fn _ -> Logger.flush end
-Logger.configure(level: :info)
-ExUnit.start exclude: [:assigns_primary_key, :array_type, :case_sensitive]
+Logger.configure(level: :error)
+ExUnit.start exclude: [:assigns_id_type, :array_type, :case_sensitive]
+
+Application.put_env(:ecto, :lock_for_update, "FOR UPDATE")
+Application.put_env(:ecto, :primary_key_type, :id)
+
 # Basic test repo
 Code.require_file "../deps/ecto/integration_test/support/repo.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/support/models.exs", __DIR__

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -83,6 +83,7 @@ Code.require_file "../deps/ecto/integration_test/cases/repo.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/type.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/pool.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/preload.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/cases/interval.exs", __DIR__
 
 
 # Load up the repository, start it, and run migrations

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -15,8 +15,7 @@ Application.put_env(:ecto, TestRepo,
   adapter: Tds.Ecto,
   filter_null_on_unique_indexes: true,
   url: "ecto://mssql:mssql@mssql.local/ecto_test",
-  size: 1,
-  max_overflow: 0)
+  pool: Ecto.Adapters.SQL.Sandbox)
 
 defmodule Ecto.Integration.TestRepo do
   use Ecto.Integration.Repo,
@@ -30,8 +29,7 @@ Application.put_env(:ecto, PoolRepo,
   adapter: Tds.Ecto,
   filter_null_on_unique_indexes: true,
   url: "ecto://mssql:mssql@mssql.local/ecto_test",
-  size: 10,
-  max_overflow: 0)
+  size: 10)
 
 defmodule Ecto.Integration.PoolRepo do
   use Ecto.Integration.Repo,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -81,6 +81,7 @@ Code.require_file "../deps/ecto/integration_test/sql/migration.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/sql/escape.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/repo.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/type.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/cases/pool.exs", __DIR__
 Code.require_file "../deps/ecto/integration_test/cases/preload.exs", __DIR__
 
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -29,7 +29,7 @@ Application.put_env(:ecto, PoolRepo,
   adapter: Tds.Ecto,
   filter_null_on_unique_indexes: true,
   url: "ecto://mssql:mssql@mssql.local/ecto_test",
-  size: 10)
+  pool_size: 10)
 
 defmodule Ecto.Integration.PoolRepo do
   use Ecto.Integration.Repo,

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -5,7 +5,6 @@ defmodule TDS.Ecto.TransactionTest do
 
   import Ecto.Query
   require Ecto.Integration.PoolRepo, as: PoolRepo
-  require Ecto.Integration.TestRepo, as: TestRepo
 
   defmodule UniqueError do
     defexception [:message]


### PR DESCRIPTION
The `to_constraints` function fails for some SQL server versions, where the error message text has changed. They also fail for error messages in languages other than English. As the error number already denotes a constraint violation, it should always be reported to Ecto, regardless of whether the constraint name could be fetched from the error message or not. I have made the functions more generic. They will also match on error message in most other languages.
