### PR TITLE
Fixed boolean literals in where clauses

### DIFF
--- a/lib/tds_ecto/connection.ex
+++ b/lib/tds_ecto/connection.ex
@@ -353,7 +353,11 @@ if Code.ensure_loaded?(Tds.Connection) do
       name <> " " <>
         Enum.map_join(query_exprs, " AND ", fn
           %QueryExpr{expr: expr} ->
-            "(" <> expr(expr, sources, query) <> ")"
+            case expr do
+              true -> "(1 = 1)"
+              false -> "(0 = 1)"
+              _ -> "(" <> expr(expr, sources, query) <> ")"
+            end  
         end)
     end
 


### PR DESCRIPTION
This fixes the failing Ecto integration tests that have a `false` in the where clause.
