### PR TITLE
Move ecto integration tests from test_helper to separate file

### DIFF
--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,0 +1,8 @@
+Code.require_file "../deps/ecto/integration_test/sql/lock.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/sql/migration.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/sql/escape.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/cases/repo.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/cases/type.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/cases/pool.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/cases/preload.exs", __DIR__
+Code.require_file "../deps/ecto/integration_test/cases/interval.exs", __DIR__

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -75,16 +75,6 @@ end
 :erlang.system_flag :backtrace_depth, 50
 # Load support models and migration
 
-Code.require_file "../deps/ecto/integration_test/sql/lock.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/sql/migration.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/sql/escape.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/cases/repo.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/cases/type.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/cases/pool.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/cases/preload.exs", __DIR__
-Code.require_file "../deps/ecto/integration_test/cases/interval.exs", __DIR__
-
-
 # Load up the repository, start it, and run migrations
 _   = Ecto.Storage.down(TestRepo)
 :ok = Ecto.Storage.up(TestRepo)


### PR DESCRIPTION
It's quite annoying that all of the Ecto integration tests are always run, even if just specifying a single test.
By moving them out from the test_helper to a separate file, individual tests can be run separately.
