### PR TITLE
Feature/fix constraints matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ defmodule MyApp.Repo do
 end
 ```
 
+tds_ecto relies on pattern matching against error messages to extract constraint names.
+If your SQL server is not configured to English as its default language you may add an `after_connect` hook to your repo and set English as the language for Ecto connections.
+
+```elixir
+def after_connect(conn) do
+  Tds.Ecto.Connection.query(conn, "SET LANGUAGE English", [], [])
+end
+```
+
 For additional information on usage please see the documentation for [Ecto](http://hexdocs.pm/ecto).
 
 ## Data Type Mapping


### PR DESCRIPTION
The `to_constraints` function fails for some SQL server versions, where the error message text has changed. It also fails for error messages in languages other than English. As the error number already denotes a constraint violation, it should always be reported to Ecto, regardless of whether the constraint name could be retrieved from the error message or not. I have made the functions more generic. They will also match on error message in most other languages.
